### PR TITLE
Create new `React.Context` for store currency data

### DIFF
--- a/react/OrderPlaced.js
+++ b/react/OrderPlaced.js
@@ -5,24 +5,26 @@ import OrderInfo from './components/OrderInfo/OrderInfo'
 import { orderGroupQuery } from './test-cases/3-pickup-only-2-delivery-only'
 import { profileQuery } from './test-cases/profileQuery'
 
+export const CurrencyContext = React.createContext('BRL')
 class OrderPlaced extends Component {
   render() {
     return (
-      <div className="center">
-        <Header data={orderGroupQuery.orderGroup} profile={profileQuery.profile} />
-        {
-          orderGroupQuery.orderGroup.map(order => {
-            return (
-              <OrderInfo
-                data={order}
-                key={order.orderId}
-                profile={profileQuery.profile}
-                currency={order.storePreferencesData.currencyCode}
-              />
-            )
-          })
-        }
-      </div>
+      <CurrencyContext.Provider value={orderGroupQuery.orderGroup[0].storePreferencesData.currencyCode}>
+        <div className="center">
+          <Header data={orderGroupQuery.orderGroup} profile={profileQuery.profile} />
+          {
+            orderGroupQuery.orderGroup.map(order => {
+              return (
+                <OrderInfo
+                  data={order}
+                  profile={profileQuery.profile}
+                  key={order.orderId}
+                />
+              )
+            })
+          }
+        </div>
+      </CurrencyContext.Provider>
     )
   }
 }

--- a/react/components/OrderInfo/OrderInfo.js
+++ b/react/components/OrderInfo/OrderInfo.js
@@ -10,7 +10,7 @@ import StorePickUp from './StorePickUp/StorePickUp'
 
 import { profileShape } from '../../proptypes/shapes'
 
-const OrderInfo = ({ data, profile, currency }) => {
+const OrderInfo = ({ data, profile }) => {
   const parcels = parcelify(data)
   return (
     <div className="mv6 w-80-ns w-90 center">
@@ -22,14 +22,13 @@ const OrderInfo = ({ data, profile, currency }) => {
         <PaymentSummary paymentsData={data.paymentData.transactions[0].payments} />
       </div>
       <div className="bb b--muted-5">
-        <Shipping data={parcels} currency={currency} />
+        <Shipping data={parcels} />
       </div>
       <div className="bb b--muted-5">
-        <StorePickUp data={parcels} currency={currency} />
+        <StorePickUp data={parcels} />
       </div>
       <OrderTotal
         items={data.items}
-        currency={data.storePreferencesData.currencyCode}
         totals={data.totals}
         orderValue={data.value}
       />
@@ -40,7 +39,6 @@ const OrderInfo = ({ data, profile, currency }) => {
 OrderInfo.propTypes = {
   data: PropTypes.object.isRequired,
   profile: profileShape.isRequired,
-  currency: PropTypes.string.isRequired,
 }
 
 export default OrderInfo

--- a/react/components/OrderInfo/OrderTotal.js
+++ b/react/components/OrderInfo/OrderTotal.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { CurrencyContext } from '../../OrderPlaced'
 
 import { FormattedPrice } from 'vtex.order-details'
 
-const ShippingTotals = ({ items, currency, totals, orderValue }) => {
+const ShippingTotals = ({ items, totals, orderValue }) => {
   let numItems = 0
 
   items.forEach(item => {
@@ -11,25 +12,29 @@ const ShippingTotals = ({ items, currency, totals, orderValue }) => {
   })
 
   return (
-    <div className="bg-muted-5 br2 pa5 mv4">
-      <div className="flex justify-between items-center">
-        <p>{`Subtotal (${numItems} itens)`}</p>
-        <FormattedPrice value={totals[0].value} currency={currency} />
-      </div>
-      <div className="flex justify-between items-center">
-        <p>Entrega</p>
-        <FormattedPrice value={totals[2].value} currency={currency} />
-      </div>
-      <div className="flex justify-between items-center">
-        <p>Retirada</p>
-        <p>Grátis</p>
-      </div>
-      <hr className="bg-muted-4 bt b--muted-4" />
-      <div className="flex justify-between items-center">
-        <p>Total</p>
-        <FormattedPrice value={orderValue} currency={currency} />
-      </div>
-    </div>
+    <CurrencyContext.Consumer>
+      {currency => (
+        <div className="bg-muted-5 br2 pa5 mv4">
+          <div className="flex justify-between items-center">
+            <p>{`Subtotal (${numItems} itens)`}</p>
+            <FormattedPrice value={totals[0].value} currency={currency} />
+          </div>
+          <div className="flex justify-between items-center">
+            <p>Entrega</p>
+            <FormattedPrice value={totals[2].value} currency={currency} />
+          </div>
+          <div className="flex justify-between items-center">
+            <p>Retirada</p>
+            <p>Grátis</p>
+          </div>
+          <hr className="bg-muted-4 bt b--muted-4" />
+          <div className="flex justify-between items-center">
+            <p>Total</p>
+            <FormattedPrice value={orderValue} currency={currency} />
+          </div>
+        </div>)
+      }
+    </CurrencyContext.Consumer>
   )
 }
 

--- a/react/components/OrderInfo/Payment/PaymentMethod.js
+++ b/react/components/OrderInfo/Payment/PaymentMethod.js
@@ -28,9 +28,7 @@ const PaymentMethod = ({ payment }) => (
         }
       </PaymentFlagPicker>
       <p>Final {payment.lastDigits}</p>
-      <div>
-        <FormattedPrice value={payment.value} currency={currency} />{` (${payment.installments}x)`}
-      </div>
+      <FormattedPrice value={payment.value} currency={currency} />{` (${payment.installments}x)`}
     </div>)}
   </CurrencyContext.Consumer>
 )

--- a/react/components/OrderInfo/Payment/PaymentMethod.js
+++ b/react/components/OrderInfo/Payment/PaymentMethod.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { FormattedPrice } from 'vtex.order-details'
 import { PaymentFlagPicker } from 'vtex.payment-flags'
 import { paymentShape } from '../../../proptypes/shapes'
+import { CurrencyContext } from '../../../OrderPlaced'
 
 // Still needs to cover all posible values for `pay.group`
 const paymentGroupSwitch = (payment) => {
@@ -14,22 +15,24 @@ const paymentGroupSwitch = (payment) => {
 }
 
 const PaymentMethod = ({ payment }) => (
-  <div className="flex flex-column justify-around mr7-ns">
-    <p className="t-heading-6">{paymentGroupSwitch(payment.group)}</p>
-    <PaymentFlagPicker paymentSystem={payment.paymentSystem}>
-      {FlagComponent =>
-        FlagComponent && (
-          <div className="h2">
-            <FlagComponent />
-          </div>
-        )
-      }
-    </PaymentFlagPicker>
-    <p>Final {payment.lastDigits}</p>
-    <div>
-      <FormattedPrice value={payment.value} currency="BRL" />{` (${payment.installments}x)`}
-    </div>
-  </div>
+  <CurrencyContext.Consumer>
+    {currency => (<div className="flex flex-column justify-around mr7-ns">
+      <p className="t-heading-6">{paymentGroupSwitch(payment.group)}</p>
+      <PaymentFlagPicker paymentSystem={payment.paymentSystem}>
+        {FlagComponent =>
+          FlagComponent && (
+            <div className="h2">
+              <FlagComponent />
+            </div>
+          )
+        }
+      </PaymentFlagPicker>
+      <p>Final {payment.lastDigits}</p>
+      <div>
+        <FormattedPrice value={payment.value} currency={currency} />{` (${payment.installments}x)`}
+      </div>
+    </div>)}
+  </CurrencyContext.Consumer>
 )
 
 PaymentMethod.propTypes = {

--- a/react/components/OrderInfo/Product.js
+++ b/react/components/OrderInfo/Product.js
@@ -1,33 +1,36 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { CurrencyContext } from '../../OrderPlaced'
 
 import { ProductImage, ProductPrice } from 'vtex.order-details'
 
-const Product = ({ productInfo, currency }) => (
-  <div className="flex items-center justify-between">
-    <div className="flex items-center">
-      <ProductImage
-        url={productInfo.imageUrl}
-        alt={productInfo.name}
-        className="w3 mr5"
-      />
-      <p href={productInfo.detailUrl} className="t-body" target="_blank">
-        {productInfo.name} <br />
-        <small className="t-mini">
-          {productInfo.quantity}
-          {productInfo.measurementUnit
-            ? productInfo.measurementUnit
-            : (productInfo.quantity > 1) ? ' unidades' : ' unidade' }
-        </small>
-      </p>
-    </div>
-    <ProductPrice value={productInfo.price * productInfo.quantity} currency={currency} />
-  </div>
+const Product = ({ productInfo }) => (
+  <CurrencyContext.Consumer>
+    {currency => (
+      <div className="flex items-center justify-between">
+        <div className="flex items-center">
+          <ProductImage
+            url={productInfo.imageUrl}
+            alt={productInfo.name}
+            className="w3 mr5"
+          />
+          <p href={productInfo.detailUrl} className="t-body" target="_blank">
+            {productInfo.name} <br />
+            <small className="t-mini">
+              {productInfo.quantity}
+              {productInfo.measurementUnit
+                ? productInfo.measurementUnit
+                : (productInfo.quantity > 1) ? ' unidades' : ' unidade' }
+            </small>
+          </p>
+        </div>
+        <ProductPrice value={productInfo.price * productInfo.quantity} currency={currency} />
+      </div>)}
+  </CurrencyContext.Consumer>
 )
 
 Product.propTypes = {
   productInfo: PropTypes.object.isRequired,
-  currency: PropTypes.string.isRequired,
 }
 
 export default Product

--- a/react/components/OrderInfo/ProductList.js
+++ b/react/components/OrderInfo/ProductList.js
@@ -1,21 +1,16 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 
 import Product from './Product'
 
-const ProductList = ({ products, currency }) => (
-  <Fragment>
-    {
-      products.map(product =>
-        <Product productInfo={product} currency={currency} key={product.id} />
-      )
-    }
-  </Fragment>
+const ProductList = ({ products }) => (
+  products.map(product =>
+    <Product productInfo={product} key={product.id} />
+  )
 )
 
 ProductList.propTypes = {
   products: PropTypes.array.isRequired,
-  currency: PropTypes.string.isRequired,
 }
 
 export default ProductList

--- a/react/components/OrderInfo/Shipping/Shipping.js
+++ b/react/components/OrderInfo/Shipping/Shipping.js
@@ -1,27 +1,22 @@
-import React, { Fragment } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import ShippingHeader from './ShippingHeader'
 import ProductList from '../ProductList'
 
-const Shipping = ({ data, currency }) => {
+const Shipping = ({ data }) => {
   const deliveryPackages = data.filter(parcel => (parcel.deliveryChannel === 'delivery'))
   return (
-    <Fragment>
-      {
-        deliveryPackages.map((delivery, index) => (
-          <div className="mv8 flex flex-column justify-between" key={index}>
-            <ShippingHeader shippingData={delivery} />
-            <ProductList products={delivery.items} currency={currency} />
-          </div>
-        ))
-      }
-    </Fragment>
+    deliveryPackages.map((delivery, index) => (
+      <div className="mv8 flex flex-column justify-between" key={index}>
+        <ShippingHeader shippingData={delivery} />
+        <ProductList products={delivery.items} />
+      </div>
+    ))
   )
 }
 
 Shipping.propTypes = {
   data: PropTypes.array.isRequired,
-  currency: PropTypes.string.isRequired,
 }
 
 export default Shipping

--- a/react/components/OrderInfo/StorePickUp/StorePickUp.js
+++ b/react/components/OrderInfo/StorePickUp/StorePickUp.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import StorePickUpHeader from './StorePickUpHeader'
 import ProductList from '../ProductList'
 
-const StorePickUp = ({ data, currency }) => {
+const StorePickUp = ({ data }) => {
   const pickUpPackages = data.filter(parcel => (parcel.deliveryChannel === 'pickup-in-point'))
   return (
     <Fragment>
@@ -12,7 +12,7 @@ const StorePickUp = ({ data, currency }) => {
         pickUpPackages.map((pickup, index) => (
           <div className="mv8 flex flex-column justify-between" key={index}>
             <StorePickUpHeader shippingData={pickup} />
-            <ProductList products={pickup.items} currency={currency} />
+            <ProductList products={pickup.items} />
           </div>
         ))
       }
@@ -22,7 +22,6 @@ const StorePickUp = ({ data, currency }) => {
 
 StorePickUp.propTypes = {
   data: PropTypes.array.isRequired,
-  currency: PropTypes.string.isRequired,
 }
 
 export default StorePickUp

--- a/react/components/OrderInfo/StorePickUp/StorePickUpHeader.js
+++ b/react/components/OrderInfo/StorePickUp/StorePickUpHeader.js
@@ -14,7 +14,7 @@ const StorePickUpHeader = ({ shippingData }) => (
 )
 
 StorePickUpHeader.propTypes = {
-  shippingData: PropTypes.array.isRequired,
+  shippingData: PropTypes.object.isRequired,
 }
 
 export default StorePickUpHeader


### PR DESCRIPTION
#### What is the purpose of this pull request?
Remove the need to pass down `currency` props from `OrderInfo` to child components.

#### What problem is this solving?
Cleaner code and easier prop management.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
