### PR TITLE
Use `vtex.shipping-estimate-translator`

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,14 +13,16 @@
   },
   "builders": {
     "react": "2.x",
-    "pages": "0.x"
+    "pages": "0.x",
+    "messages": "0.x"
   },
   "dependencies": {
     "vtex.order-placed-graphql": "0.x",
     "vtex.styleguide": "8.x",
     "vtex.store-graphql": "2.x",
     "vtex.order-details": "0.x",
-    "vtex.payment-flags": "1.x"
+    "vtex.payment-flags": "1.x",
+    "vtex.shipping-estimate-translator": "1.x"
   },
   "credentialType": "absolute",
   "policies": [

--- a/react/components/OrderInfo/Shipping/ShippingHeader.js
+++ b/react/components/OrderInfo/Shipping/ShippingHeader.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { PrettyAddress } from 'vtex.order-details'
+import TranslateEstimate from 'vtex.shipping-estimate-translator/TranslateEstimate'
 
 const ShippingHeader = ({ shippingData }) => (
   <div className="flex flex-column">
@@ -8,7 +9,7 @@ const ShippingHeader = ({ shippingData }) => (
       Entrega em casa
       <br />
       <small className="c-muted-2 t-small">
-        Em até {shippingData.shippingEstimate} dias úteis
+        <TranslateEstimate shippingEstimate={shippingData.shippingEstimate} />
       </small>
     </p>
     <PrettyAddress address={shippingData.address} />

--- a/react/components/OrderInfo/StorePickUp/StorePickUpHeader.js
+++ b/react/components/OrderInfo/StorePickUp/StorePickUpHeader.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { TranslateEstimate } from 'vtex.shipping-estimate-translator'
 
 const StorePickUpHeader = ({ shippingData }) => (
   <div className="flex flex-column flex-wrap">
@@ -7,7 +8,7 @@ const StorePickUpHeader = ({ shippingData }) => (
       Retirada no ponto
       <br />
       <small className="c-muted-2 t-small">
-        Pronto em até {shippingData.shippingEstimate} dias úteis
+        <TranslateEstimate shippingEstimate={shippingData.shippingEstimate} isPickup />
       </small>
     </p>
   </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Display correct shipping estimates.

#### What problem is this solving?
Shipping estimates being shown just as they arrive from the API.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
