### PR TITLE
Better measurement unit support

### DIFF
--- a/.vtex/cy.yml
+++ b/.vtex/cy.yml
@@ -3,14 +3,13 @@ phases:
   install:
     commands:
       - echo Installing Packages...
+      - cd react
       - npm install
       - echo Packages installed!
   pre_build:
     commands:
-      - echo Building application...
-      - npm run build:symlinks
-      - echo Build finished!
       - echo Running tests...
+      - cd react
       - npm run test
       - echo Tests finished!
 cache:

--- a/react/.eslintrc
+++ b/react/.eslintrc
@@ -14,6 +14,11 @@
     ],
     "no-console": ["error", { "allow": ["warn", "error"] }]
   },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
+  },
   "env": {
     "browser": true,
     "node": true,

--- a/react/OrderPlaced.js
+++ b/react/OrderPlaced.js
@@ -29,7 +29,8 @@ class OrderPlaced extends Component {
               order={order}
               profile={order.clientProfileData}
               numOfOrders={orderGroupQuery.orderGroup.length}
-              key={index}
+              index={index}
+              key={order.orderId}
             />
           ))}
         </main>

--- a/react/components/OrderInfo/index.js
+++ b/react/components/OrderInfo/index.js
@@ -76,8 +76,8 @@ const OrderInfo = ({ order, profile, numOfOrders, key }) => {
 OrderInfo.propTypes = {
   order: PropTypes.object.isRequired,
   profile: profileShape.isRequired,
-  numOfOrders: PropTypes.number.isRequired,
-  key: PropTypes.number.isRequired,
+  numOfOrders: PropTypes.number,
+  key: PropTypes.number,
 }
 
 export default OrderInfo

--- a/react/components/OrderInfo/index.js
+++ b/react/components/OrderInfo/index.js
@@ -18,7 +18,7 @@ import {
 } from '../../utils'
 import OrderOptions from './OrderOptions'
 
-const OrderInfo = ({ order, profile, numOfOrders, key }) => {
+const OrderInfo = ({ order, profile, numOfOrders, index }) => {
   const splitOrder = numOfOrders > 1
   const parcels = parcelify(order)
   const delivery = getDeliveryPackagesFromParcels(parcels)
@@ -68,7 +68,7 @@ const OrderInfo = ({ order, profile, numOfOrders, key }) => {
           orderValue={order.value}
         />
       </div>
-      {key < numOfOrders - 1 && <hr className="bg-muted-4 bt b--muted-4" />}
+      {index < numOfOrders - 1 && <hr className="bg-muted-4 bt b--muted-4" />}
     </section>
   )
 }
@@ -77,7 +77,7 @@ OrderInfo.propTypes = {
   order: PropTypes.object.isRequired,
   profile: profileShape.isRequired,
   numOfOrders: PropTypes.number,
-  key: PropTypes.number,
+  index: PropTypes.number,
 }
 
 export default OrderInfo

--- a/react/components/ProductList/Product.js
+++ b/react/components/ProductList/Product.js
@@ -5,42 +5,49 @@ import { ProductImage } from 'vtex.order-details'
 import { intlMessage } from '../../utils'
 import FormattedPrice from '../Payment/FormattedPrice'
 
-const Product = ({ productInfo, intl }) => (
-  <article className="flex justify-between mv4 flex-column-s flex-row-m">
-    <div className="flex items-center flex-column flex-row-m">
-      <ProductImage
-        url={productInfo.imageUrl}
-        alt={productInfo.name}
-        className="w3 mr5"
-      />
-      <div className="flex flex-column items-between h-100">
-        <a
-          href={productInfo.detailUrl}
-          className="t-body c-muted-1 no-underline"
-          target="_blank"
-        >
-          <p>
-            {productInfo.name}
-            {productInfo.measurementUnit !== 'un' && (
-              <small className="t-mini c-on-base tc tl-m">
-                <br />
-                {`${productInfo.unitMultiplier} ${productInfo.measurementUnit}`}
-              </small>
-            )}
+const Product = ({ productInfo, intl }) => {
+  const showMeasurementUnit =
+    productInfo.unitMultiplier !== 1 || productInfo.measurementUnit !== 'un'
+
+  return (
+    <article className="flex justify-between mv4 flex-column-s flex-row-m">
+      <div className="flex items-center flex-column flex-row-m">
+        <ProductImage
+          url={productInfo.imageUrl}
+          alt={productInfo.name}
+          className="w3 mr5"
+        />
+        <div className="flex flex-column items-between h-100">
+          <a
+            href={productInfo.detailUrl}
+            className="t-body c-muted-1 no-underline"
+            target="_blank"
+          >
+            <p>
+              {productInfo.name}
+              {showMeasurementUnit && (
+                <small className="t-mini c-on-base tc tl-m">
+                  <br />
+                  {`${productInfo.unitMultiplier} ${
+                    productInfo.measurementUnit
+                  }`}
+                </small>
+              )}
+            </p>
+          </a>
+          <p className="t-mini c-muted-1 tc tl-m">
+            {intlMessage(intl, 'products.quantity', {
+              quantity: productInfo.quantity,
+            })}
           </p>
-        </a>
-        <p className="t-mini c-muted-1 tc tl-m">
-          {intlMessage(intl, 'products.quantity', {
-            quantity: productInfo.quantity,
-          })}
-        </p>
+        </div>
       </div>
-    </div>
-    <p className="tc tr-m">
-      <FormattedPrice value={productInfo.price * productInfo.quantity} />
-    </p>
-  </article>
-)
+      <p className="tc tr-m">
+        <FormattedPrice value={productInfo.price * productInfo.quantity} />
+      </p>
+    </article>
+  )
+}
 
 Product.propTypes = {
   productInfo: PropTypes.object.isRequired,


### PR DESCRIPTION
#### What is the purpose of this pull request?
`Product` component can handle products with measurement units different from 'un' and multipliers different from 1 better.

#### What problem is this solving?
If the product had 'un' as measurement unit, but a multiplier different from 1, that would be ignored and not rendered.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
