### PR TITLE
Create loading skeleton

### DIFF
--- a/react/OrderPlaced.js
+++ b/react/OrderPlaced.js
@@ -2,11 +2,11 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { compose, graphql } from 'react-apollo'
 import { branch, renderComponent } from 'recompose'
-import { Loader } from 'vtex.order-details'
 import { withRuntimeContext } from 'vtex.render-runtime'
 
 import Header from './components/Header'
 import OrderInfo from './components/OrderInfo'
+import Skeleton from './Skeleton'
 import getOrderGroup from './graphql/getOrderGroup.graphql'
 import withoutSSR from './withoutSSR'
 
@@ -63,6 +63,6 @@ export default compose(
   }),
   branch(
     ({ orderGroupQuery }) => orderGroupQuery.loading,
-    renderComponent(Loader)
+    renderComponent(Skeleton)
   )
 )(OrderPlaced)

--- a/react/Skeleton.js
+++ b/react/Skeleton.js
@@ -1,0 +1,44 @@
+import React from 'react'
+import './styles.global.css'
+
+const Skeleton = () => {
+  const baseSkeletonPiece = 'pa3 br2 relative overflow-hidden'
+  return (
+    <div className="w-90 mw8 center pv10 flex flex-column justify-between items-center">
+      <div
+        className={`${baseSkeletonPiece} bg-muted-4 mv3 w-30 mv7`}
+        style={{ height: `${24}px` }}
+      >
+        <div className="skeleton-shimmer" />
+      </div>
+      <div
+        className={`${baseSkeletonPiece} bg-muted-4 mv2 w-75-m w-80`}
+        style={{ height: `${20}px` }}
+      >
+        <div className="skeleton-shimmer" />
+      </div>
+      <div
+        className={`${baseSkeletonPiece} bg-muted-4 mv2 w-60`}
+        style={{ height: `${20}px` }}
+      >
+        <div className="skeleton-shimmer" />
+      </div>
+      <div className="flex justify-center pv8 w-100">
+        <div
+          className={`${baseSkeletonPiece} bg-muted-4 mv3 w-30 w-20-m mr3`}
+          style={{ height: `${36}px` }}
+        >
+          <div className="skeleton-shimmer" />
+        </div>
+        <div
+          className={`${baseSkeletonPiece} bg-muted-4 mv3 w-30 w-20-m ml3`}
+          style={{ height: `${36}px` }}
+        >
+          <div className="skeleton-shimmer" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default Skeleton

--- a/react/__mocks__/styleMock.js
+++ b/react/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+export default {}

--- a/react/package.json
+++ b/react/package.json
@@ -43,6 +43,9 @@
     "lint:locales": "intl-equalizer"
   },
   "jest": {
+    "moduleNameMapper": {
+      "\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js"
+    },
     "setupTestFrameworkScriptFile": "./testUtils/setupTests.js",
     "collectCoverageFrom": [
       "react/**/*.{js,jsx}"

--- a/react/styles.global.css
+++ b/react/styles.global.css
@@ -9,11 +9,7 @@
 }
 
 .skeleton-shimmer {
-  width: 200%;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  left: -100%;
+  animation: shimmer-anim 0.7s linear infinite;
   background: linear-gradient(
     90deg,
     rgba(255, 255, 255, 0),
@@ -21,5 +17,9 @@
     rgba(255, 255, 255, 0)
   );
   background-size: 50% 100%;
-  animation: shimmer-anim 0.7s linear infinite;
+  height: 100%;
+  left: -100%;
+  position: absolute;
+  top: 0;
+  width: 200%;
 }

--- a/react/styles.global.css
+++ b/react/styles.global.css
@@ -1,0 +1,25 @@
+/* Skeleton animation */
+@keyframes shimmer-anim {
+  0% {
+    transform: translate3d(0, 0, 0);
+  }
+  100% {
+    transform: translate3d(50%, 0, 0);
+  }
+}
+
+.skeleton-shimmer {
+  width: 200%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: -100%;
+  background: linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0),
+    rgba(255, 255, 255, 0.7),
+    rgba(255, 255, 255, 0)
+  );
+  background-size: 50% 100%;
+  animation: shimmer-anim 0.7s linear infinite;
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add a loading skeleton to be displayed while the app is loading.

#### What problem is this solving?
The app was using a simple spinner to indicate loading.

#### Screenshots or example usage

<img width="1911" alt="screen shot 2019-02-01 at 11 15 26 am" src="https://user-images.githubusercontent.com/27777263/52125165-b76ab000-2612-11e9-990a-760c4cb3262d.png">


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
