### PR TITLE
Integrate action buttons to Dreamstore routes

### DIFF
--- a/react/components/ButtonLink.tsx
+++ b/react/components/ButtonLink.tsx
@@ -4,6 +4,8 @@ import { Button, ButtonWithIcon } from 'vtex.styleguide'
 interface Props {
   url: string
   icon?: ReactNode
+  fullWidth?: boolean
+  openNewWindow?: boolean
   variation: string
   children: ReactChild
 }
@@ -11,16 +13,20 @@ interface Props {
 const ButtonLink: FunctionComponent<Props> = ({
   url,
   icon,
+  fullWidth,
+  openNewWindow,
   variation,
   children,
 }) => (
-  <a href={url} target="_blank">
+  <a href={url} target={openNewWindow ? '_blank' : ''}>
     {icon ? (
-      <ButtonWithIcon icon={icon} variation={variation}>
+      <ButtonWithIcon icon={icon} variation={variation} block={fullWidth}>
         {children}
       </ButtonWithIcon>
     ) : (
-      <Button variation={variation}>{children}</Button>
+      <Button variation={variation} block={fullWidth}>
+        {children}
+      </Button>
     )}
   </a>
 )

--- a/react/components/Header/BankInvoice/index.tsx
+++ b/react/components/Header/BankInvoice/index.tsx
@@ -30,7 +30,12 @@ const BankInvoice: FunctionComponent<Props & InjectedIntlProps> = ({
     </header>
     <article className="flex justify-between items-center">
       {invoiceBarCodeNumber && <BarCode barCodeNumber={invoiceBarCodeNumber} />}
-      <ButtonLink url={url} icon={<PrinterIcon />} variation="secondary">
+      <ButtonLink
+        url={url}
+        icon={<PrinterIcon />}
+        variation="secondary"
+        openNewWindow
+      >
         {intl.formatMessage(
           { id: 'header.bankinvoice.print' },
           { paymentSystemName: paymentSystem }

--- a/react/components/Header/Warnings.tsx
+++ b/react/components/Header/Warnings.tsx
@@ -127,7 +127,11 @@ const Warnings: FunctionComponent<Props & InjectedIntlProps> = ({
                   )}
                 </p>
                 {bankInvoices[0].url && (
-                  <ButtonLink url={bankInvoices[0].url} variation="primary">
+                  <ButtonLink
+                    url={bankInvoices[0].url}
+                    variation="primary"
+                    openNewWindow
+                  >
                     {intl.formatMessage(
                       { id: 'payments.bankinvoice.print' },
                       { paymentSystemName: bankInvoices[0].paymentSystemName }

--- a/react/components/Header/index.tsx
+++ b/react/components/Header/index.tsx
@@ -8,6 +8,7 @@ import {
   getTotalParcelsFromOrderGroup,
   PaymentGroupInfo
 } from '../../utils'
+import ButtonLink from '../ButtonLink'
 import BankInvoice from './BankInvoice'
 import Summary from './Summary'
 import Warnings from './Warnings'
@@ -81,9 +82,9 @@ const Header: FunctionComponent<Props & InjectedIntlProps> = ({
           </div>
           {inStore && (
             <div className="tr c-action-primary ml4">
-              <Button variation="primary">
+              <ButtonLink variation="primary" url="/checkout/instore#/">
                 {intl.formatMessage({ id: 'header.newpurchase.button' })}
-              </Button>
+              </ButtonLink>
             </div>
           )}
         </div>

--- a/react/components/Header/index.tsx
+++ b/react/components/Header/index.tsx
@@ -75,7 +75,7 @@ const Header: FunctionComponent<Props & InjectedIntlProps> = ({
             </Button>
           </div>
           <div className="tr c-action-primary ml4">
-            <Button variation="secondary">
+            <Button variation="secondary" onClick={() => window.print()}>
               {intl.formatMessage({ id: 'header.print.button' })}
             </Button>
           </div>

--- a/react/components/OrderInfo/OrderHeader.tsx
+++ b/react/components/OrderInfo/OrderHeader.tsx
@@ -65,6 +65,7 @@ const OrderHeader: FunctionComponent<
       <OrderOptions
         className="dn-s flex-l"
         allowCancellation={orderInfo.allowCancellation}
+        orderId={orderInfo.orderId}
         takeaway={takeaway}
       />
     </header>

--- a/react/components/OrderInfo/OrderOptions.tsx
+++ b/react/components/OrderInfo/OrderOptions.tsx
@@ -1,12 +1,13 @@
 import React, { FunctionComponent } from 'react'
 import { InjectedIntlProps, injectIntl } from 'react-intl'
-import { Button } from 'vtex.styleguide'
+import ButtonLink from '../ButtonLink'
 
 interface Props {
   allowCancellation: boolean
   takeaway?: boolean
   className?: string
   fullWidth?: boolean
+  orderId?: string
 }
 
 const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
@@ -15,31 +16,54 @@ const OrderOptions: FunctionComponent<Props & InjectedIntlProps> = ({
   intl,
   className = '',
   fullWidth,
+  orderId,
 }) => (
   <div className={`${className} flex flex-wrap justify-between flex-nowrap-m`}>
     <div className="mr3-ns mb4-s mb0-m w-100 w-auto-m">
-      <Button variation="secondary" block={fullWidth}>
-        {takeaway
-          ? intl.formatMessage({
-              id: 'order.header.takeaway.printreceipt.button',
-            })
-          : intl.formatMessage({ id: 'order.header.update.button' })}
-      </Button>
+      {takeaway ? (
+        <ButtonLink variation="secondary" fullWidth={fullWidth} url="">
+          {intl.formatMessage({
+            id: 'order.header.takeaway.printreceipt.button',
+          })}
+        </ButtonLink>
+      ) : (
+        <ButtonLink
+          variation="secondary"
+          fullWidth={fullWidth}
+          url={`/account#/orders/${orderId}`}
+        >
+          {intl.formatMessage({ id: 'order.header.update.button' })}
+        </ButtonLink>
+      )}
     </div>
     {!takeaway && (
       <div className="mr3-ns mb4-s mb0-m w-100 w-auto-m">
-        <Button variation="secondary" block={fullWidth}>
+        <ButtonLink
+          variation="secondary"
+          fullWidth={fullWidth}
+          url="/account#/orders/"
+        >
           {intl.formatMessage({ id: 'order.header.myorders.button' })}
-        </Button>
+        </ButtonLink>
       </div>
     )}
     {allowCancellation && (
       <div className="w-100 w-auto-m">
-        <Button variation="danger-tertiary" block={fullWidth}>
-          {takeaway
-            ? intl.formatMessage({ id: 'order.header.takeaway.cancel.button' })
-            : intl.formatMessage({ id: 'order.header.cancel.button' })}
-        </Button>
+        {takeaway ? (
+          <ButtonLink variation="danger-tertiary" fullWidth={fullWidth} url="">
+            {intl.formatMessage({
+              id: 'order.header.takeaway.cancel.button',
+            })}
+          </ButtonLink>
+        ) : (
+          <ButtonLink
+            variation="danger-tertiary"
+            fullWidth={fullWidth}
+            url={`/account#/orders/${orderId}/cancel`}
+          >
+            {intl.formatMessage({ id: 'order.header.cancel.button' })}
+          </ButtonLink>
+        )}
       </div>
     )}
   </div>

--- a/react/components/Payment/PaymentMethod.tsx
+++ b/react/components/Payment/PaymentMethod.tsx
@@ -62,7 +62,7 @@ class PaymentMethod extends Component<Props & InjectedIntlProps> {
             )}`}
           </p>
           {isBankInvoice && payment.url && (
-            <ButtonLink url={payment.url} variation="primary">
+            <ButtonLink url={payment.url} variation="primary" openNewWindow>
               {intl.formatMessage(
                 { id: 'payments.bankinvoice.print' },
                 { paymentSystemName: payment.paymentSystemName }


### PR DESCRIPTION
#### What is the purpose of this pull request?
Make buttons shown on `Header` and `OrderHeader` redirect the user to correct `MyAccount` route.
Also make `Print this page` button trigger `window.print()` to the browser.

#### What problem is this solving?
Buttons had no links associated with them.

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
