### PR TITLE
Fix unit/units translation in english

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrong translation of `unit` and `units`.
+
 ## [1.2.1] - 2019-06-10
 
 ### Fixed

--- a/messages/en.json
+++ b/messages/en.json
@@ -51,7 +51,7 @@
   "payments.installments": "({installments}x)",
   "payments.transaction.id": "Transaction ID: {id}",
   "pickup.header.title": "Pickup",
-  "products.quantity": "{quantity, plural, one {# unity} other {# unities}}",
+  "products.quantity": "{quantity, plural, one {# unit} other {# units}}",
   "shipping.header.title": "Delivery",
   "shipping.header.wishlist.address": "Address from: {giftRegistryName}",
   "summary.items": "{itemsQuantity, plural, one {# item} other {# items}}",


### PR DESCRIPTION
#### What is the purpose of this pull request?

Fix `unit`, `units` translation.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

Current translation is `unity` and `unities`.

#### How should this be manually tested?

Open an order-placed page and check the quantity number of a certain product.

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
