### PR TITLE
Make the user log in before seeing the bank invoice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Links to the bank invoice. The user has to be signed in to see it.
+
 ## [1.4.1] - 2019-08-06
 
 ### Fixed

--- a/react/__mocks__/vtex.order-details.tsx
+++ b/react/__mocks__/vtex.order-details.tsx
@@ -1,25 +1,24 @@
-import React, { Component } from 'react'
+import React, { FunctionComponent } from 'react'
 
 export function FormattedDate() {
   return <span>FormattedDate</span>
-}
-
-export class ProductImage extends Component {
-  public render() {
-    return <div>ProductImage</div>
-  }
 }
 
 export function Address() {
   return <span>Address</span>
 }
 
-export class ButtonLink extends Component {
-  public render() {
-    return <span>{this.props.children}</span>
-  }
-}
-
 export function CustomerInfo() {
   return <span>CustomerInfo</span>
 }
+
+export const ProductImage: FunctionComponent = () => <div>ProductImage</div>
+
+export const ButtonLink: FunctionComponent<{ to: string }> = ({
+  to,
+  children,
+}) => (
+  <a href={to} data-testid="button-link">
+    {children}
+  </a>
+)

--- a/react/__tests__/BankInvoice.test.tsx
+++ b/react/__tests__/BankInvoice.test.tsx
@@ -89,4 +89,26 @@ describe('Bank invoice scenarios', () => {
 
     expect(bankInvoiceSection).toBeNull()
   })
+  it('should have the invoice url if the user is logged in.', () => {
+    const { queryByTestId } = render(
+      <Header
+        orderGroup={bankInvoiceLoggedIn.orderGroup}
+        profile={bankInvoiceLoggedIn.orderGroup.orders[0].clientProfileData}
+      />
+    )
+    const printButton = queryByTestId('button-link') as any
+
+    expect((printButton.href as string).includes('login')).toBe(false)
+  })
+  it('should redirect to login if the user is not logged in.', () => {
+    const { queryByTestId } = render(
+      <Header
+        orderGroup={bankInvoiceNotLoggedIn.orderGroup}
+        profile={bankInvoiceNotLoggedIn.orderGroup.orders[0].clientProfileData}
+      />
+    )
+    const printButton = queryByTestId('button-link') as any
+
+    expect((printButton.href as string).includes('login')).toBe(true)
+  })
 })

--- a/react/components/Header/Warnings.tsx
+++ b/react/components/Header/Warnings.tsx
@@ -3,8 +3,8 @@ import { FormattedMessage } from 'react-intl'
 import { FormattedDate } from 'vtex.order-details'
 import { ButtonLink } from 'vtex.order-details'
 
-import { PaymentGroupInfo } from '../../utils'
 import Price from '../Payment/FormattedPrice'
+import { PaymentGroupInfo, parseBankInvoiceUrl } from '../../utils'
 
 const Warnings: FunctionComponent<Props> = ({
   numOfOrders,
@@ -113,7 +113,7 @@ const Warnings: FunctionComponent<Props> = ({
                 </p>
                 {bankInvoices[0].url && (
                   <ButtonLink
-                    to={bankInvoices[0].url}
+                    to={parseBankInvoiceUrl(bankInvoices[0].url)}
                     variation="primary"
                     openNewWindow
                   >

--- a/react/components/Header/index.tsx
+++ b/react/components/Header/index.tsx
@@ -4,7 +4,11 @@ import { ButtonLink } from 'vtex.order-details'
 import { Button } from 'vtex.styleguide'
 
 import SuccessIcon from '../../Icons/Success'
-import { getPaymentGroupFromOrder, PaymentGroupInfo } from '../../utils'
+import {
+  getPaymentGroupFromOrder,
+  PaymentGroupInfo,
+  parseBankInvoiceUrl,
+} from '../../utils'
 import BankInvoice from './BankInvoice'
 import Summary from './Summary'
 import Warnings from './Warnings'
@@ -79,7 +83,7 @@ const Header: FunctionComponent<Props> = ({ orderGroup, profile, inStore }) => {
       )}
       {hasBankInvoice && bankInvoices[0].url && !hideBankInvoiceInfo && (
         <BankInvoice
-          url={bankInvoices[0].url}
+          url={parseBankInvoiceUrl(bankInvoices[0].url)}
           encrypted={!!encrypted}
           invoiceBarCodeNumber={bankInvoices[0].barCodeNumber}
           paymentSystem={bankInvoices[0].paymentSystemName}

--- a/react/components/Payment/PaymentMethod.tsx
+++ b/react/components/Payment/PaymentMethod.tsx
@@ -8,11 +8,13 @@ import {
 import { ButtonLink } from 'vtex.order-details'
 
 import InfoIcon from '../../Icons/Info'
+import {
+  transformConnectorResponsesToArray,
+  parseBankInvoiceUrl,
+} from '../../utils'
 import AdditionalInfo from './AdditionalInfo'
 import Price from './FormattedPrice'
 import ConnectorResponseInfo from './ConnectorResponseInfo'
-
-import { transformConnectorResponsesToArray } from '../../utils'
 
 const messages = defineMessages({
   creditCard: {
@@ -92,7 +94,11 @@ const PaymentMethod: FunctionComponent<Props & InjectedIntlProps> = ({
         </div>
         {isBankInvoice && payment.url && (
           <div className="mt5">
-            <ButtonLink to={payment.url} variation="primary" openNewWindow>
+            <ButtonLink
+              to={parseBankInvoiceUrl(payment.url)}
+              variation="primary"
+              openNewWindow
+            >
               <FormattedMessage
                 id="store/payments.bankinvoice.print"
                 values={{ paymentSystemName: payment.paymentSystemName }}

--- a/react/utils/index.tsx
+++ b/react/utils/index.tsx
@@ -188,3 +188,14 @@ export function orderSplitMessage({
     takeaways,
   })
 }
+
+export function parseBankInvoiceUrl(url: string) {
+  const isEncrypted = url.match(/(\*.\*.)+\*\w\*/g)
+
+  if (!isEncrypted) return url
+  if (!window || !window.location) return ''
+
+  return `/login?returnUrl=${encodeURIComponent(
+    window.location.pathname + window.location.search
+  )}`
+}

--- a/react/utils/index.tsx
+++ b/react/utils/index.tsx
@@ -195,7 +195,7 @@ export function parseBankInvoiceUrl(url: string) {
   if (!isEncrypted) return url
   if (!window || !window.location) return ''
 
-  return `/login?returnUrl=${encodeURIComponent(
+  return `${__RUNTIME__.rootPath || ''}/login?returnUrl=${encodeURIComponent(
     window.location.pathname + window.location.search
   )}`
 }

--- a/react/utils/index.tsx
+++ b/react/utils/index.tsx
@@ -193,9 +193,12 @@ export function parseBankInvoiceUrl(url: string) {
   const isEncrypted = !!url.match(/(\*.\*.)+\*\w\*/g)
 
   if (!isEncrypted) return url
-  if (!window || !window.location) return ''
 
-  return `${window.__RUNTIME__.rootPath || ''}/login?returnUrl=${encodeURIComponent(
+  return `${get(
+    window,
+    '__RUNTIME__.rootPath',
+    ''
+  )}/login?returnUrl=${encodeURIComponent(
     window.location.pathname + window.location.search
   )}`
 }

--- a/react/utils/index.tsx
+++ b/react/utils/index.tsx
@@ -190,7 +190,7 @@ export function orderSplitMessage({
 }
 
 export function parseBankInvoiceUrl(url: string) {
-  const isEncrypted = url.match(/(\*.\*.)+\*\w\*/g)
+  const isEncrypted = !!url.match(/(\*.\*.)+\*\w\*/g)
 
   if (!isEncrypted) return url
   if (!window || !window.location) return ''

--- a/react/utils/index.tsx
+++ b/react/utils/index.tsx
@@ -195,7 +195,7 @@ export function parseBankInvoiceUrl(url: string) {
   if (!isEncrypted) return url
   if (!window || !window.location) return ''
 
-  return `${__RUNTIME__.rootPath || ''}/login?returnUrl=${encodeURIComponent(
+  return `${window.__RUNTIME__.rootPath || ''}/login?returnUrl=${encodeURIComponent(
     window.location.pathname + window.location.search
   )}`
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?
- ditto.

#### What problem is this solving?
- The checkout doesn't return the correct url when the user isn't indentified. Therefore we need to make him log in first before he can see the bank invoice it self.

#### How should this be manually tested?

https://felipe--boticario.myvtex.com/checkout/orderPlaced/?og=v83637215bot

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
