### PR TITLE
Add promotion banner to promote web app in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Web App Install Promotion Banner at the end of the page.
+
 ## [1.5.0] - 2019-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- Web App Install Promotion Banner at the end of the page.
+- Install Promotion Banner at the end of the page.
 
 ## [1.5.0] - 2019-09-09
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,9 @@
   "version": "1.5.0",
   "title": "Order Placed",
   "description": "",
-  "registries": ["smartcheckout"],
+  "registries": [
+    "smartcheckout"
+  ],
   "scripts": {
     "postreleasy": "vtex publish --public"
   },
@@ -21,7 +23,9 @@
     "vtex.shipping-estimate-translator": "2.x",
     "vtex.address-form": "4.x",
     "vtex.profile-form": "3.x",
-    "vtex.pixel-manager": "1.x"
+    "vtex.pixel-manager": "1.x",
+    "vtex.pwa-components": "0.x",
+    "vtex.store-resources": "0.x"
   },
   "credentialType": "absolute",
   "policies": [

--- a/react/OrderPlaced.tsx
+++ b/react/OrderPlaced.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useState } from 'react'
 import { compose, graphql } from 'react-apollo'
 import {
   injectIntl,
@@ -57,6 +57,8 @@ const OrderPlaced: FunctionComponent<Props & InjectedIntlProps> = ({
   const { orderGroup } = orderGroupQuery
   const { settings = {} } = usePWA() || {}
   const { promptOnCustomEvent } = settings
+  const [installDismissed, setInstallDismissed] = useState(false)
+
   return (
     <CurrencyContext.Provider
       value={orderGroup.orders[0].storePreferencesData.currencyCode}>
@@ -80,8 +82,14 @@ const OrderPlaced: FunctionComponent<Props & InjectedIntlProps> = ({
             key={order.orderId}
           />
         ))}
-        {promptOnCustomEvent === 'checkout' && (
-          <ExtensionPoint id="promotion-banner" type="install" />
+        {promptOnCustomEvent === 'checkout' && !installDismissed && (
+          <ExtensionPoint
+            id="promotion-banner"
+            type="install"
+            onDismiss={() => {
+              setInstallDismissed(true)
+            }}
+          />
         )}
       </main>
     </CurrencyContext.Provider>

--- a/react/OrderPlaced.tsx
+++ b/react/OrderPlaced.tsx
@@ -81,7 +81,7 @@ const OrderPlaced: FunctionComponent<Props & InjectedIntlProps> = ({
           />
         ))}
         {promptOnCustomEvent === 'checkout' && (
-          <ExtensionPoint id="promotion-banner" />
+          <ExtensionPoint id="promotion-banner" type="install" />
         )}
       </main>
     </CurrencyContext.Provider>

--- a/react/OrderPlaced.tsx
+++ b/react/OrderPlaced.tsx
@@ -10,6 +10,7 @@ import { branch, renderComponent } from 'recompose'
 
 import { Helmet, withRuntimeContext, ExtensionPoint } from 'vtex.render-runtime'
 import { Button } from 'vtex.styleguide'
+import { usePWA } from 'vtex.store-resources/PWAContext'
 
 import AnalyticsWrapper from './Analytics'
 import Header from './components/Header'
@@ -54,7 +55,8 @@ const OrderPlaced: FunctionComponent<Props & InjectedIntlProps> = ({
   intl,
 }) => {
   const { orderGroup } = orderGroupQuery
-
+  const { settings = {} } = usePWA() || {}
+  const { promptOnCustomEvent } = settings
   return (
     <CurrencyContext.Provider
       value={orderGroup.orders[0].storePreferencesData.currencyCode}>
@@ -68,7 +70,7 @@ const OrderPlaced: FunctionComponent<Props & InjectedIntlProps> = ({
         profile={orderGroup.orders[0].clientProfileData}
         inStore={inStore}
       />
-      <main>
+      <main className="mv6 w-80-ns w-90 center">
         {orderGroup.orders.map((order: Order, index: number) => (
           <OrderInfo
             order={order}
@@ -78,6 +80,9 @@ const OrderPlaced: FunctionComponent<Props & InjectedIntlProps> = ({
             key={order.orderId}
           />
         ))}
+        {promptOnCustomEvent === 'checkout' && (
+          <ExtensionPoint id="promotion-banner" />
+        )}
       </main>
     </CurrencyContext.Provider>
   )

--- a/react/components/OrderInfo/index.tsx
+++ b/react/components/OrderInfo/index.tsx
@@ -38,61 +38,56 @@ const OrderInfo: FunctionComponent<Props> = ({
 
   return (
     <section>
-      <div>
-        <OrderHeader
-          orderInfo={order}
-          splitOrder={splitOrder}
-          takeaway={takeaway.length > 0}
+      <OrderHeader
+        orderInfo={order}
+        splitOrder={splitOrder}
+        takeaway={takeaway.length > 0}
+      />
+      {multipleDeliveries && (
+        <OrderSplitNotice
+          deliveries={delivery.length}
+          pickups={pickup.length}
+          takeaways={takeaway.length}
         />
-        {multipleDeliveries && (
-          <OrderSplitNotice
-            deliveries={delivery.length}
-            pickups={pickup.length}
-            takeaways={takeaway.length}
-          />
-        )}
-        {hasCustomerName && <CustomerInfo profile={profile} />}
+      )}
+      {hasCustomerName && <CustomerInfo profile={profile} />}
+      <OrderSection>
+        <div className="flex flex-column flex-row-m">
+          {paymentsData.map((payment, idx) => (
+            <div key={idx} className="pb8-s mr9-m">
+              <PaymentMethod payment={payment} transactionId={transactionId} />
+            </div>
+          ))}
+        </div>
+        <OrderOptions
+          className="dn-l mb8"
+          allowCancellation={order.allowCancellation}
+          fullWidth
+        />
+      </OrderSection>
+      {pickup.length > 0 && (
         <OrderSection>
-          <div className="flex flex-column flex-row-m">
-            {paymentsData.map((payment, idx) => (
-              <div key={idx} className="pb8-s mr9-m">
-                <PaymentMethod
-                  payment={payment}
-                  transactionId={transactionId}
-                />
-              </div>
-            ))}
-          </div>
-          <OrderOptions
-            className="dn-l mb8"
-            allowCancellation={order.allowCancellation}
-            fullWidth
+          <StorePickUp pickUpPackages={pickup} />
+        </OrderSection>
+      )}
+      {delivery.length > 0 && (
+        <OrderSection>
+          <Shipping
+            deliveryPackages={delivery}
+            giftRegistryData={giftRegistryData}
           />
         </OrderSection>
-        {pickup.length > 0 && (
-          <OrderSection>
-            <StorePickUp pickUpPackages={pickup} />
-          </OrderSection>
-        )}
-        {delivery.length > 0 && (
-          <OrderSection>
-            <Shipping
-              deliveryPackages={delivery}
-              giftRegistryData={giftRegistryData}
-            />
-          </OrderSection>
-        )}
-        {takeaway.length > 0 && (
-          <OrderSection>
-            <TakeAway takeAwayPackages={takeaway} />
-          </OrderSection>
-        )}
-        <OrderTotal
-          items={order.items}
-          totals={order.totals}
-          orderValue={order.value}
-        />
-      </div>
+      )}
+      {takeaway.length > 0 && (
+        <OrderSection>
+          <TakeAway takeAwayPackages={takeaway} />
+        </OrderSection>
+      )}
+      <OrderTotal
+        items={order.items}
+        totals={order.totals}
+        orderValue={order.value}
+      />
       {index < numOfOrders - 1 && <hr className="bg-muted-4 bt b--muted-4" />}
     </section>
   )

--- a/react/components/OrderInfo/index.tsx
+++ b/react/components/OrderInfo/index.tsx
@@ -38,7 +38,7 @@ const OrderInfo: FunctionComponent<Props> = ({
 
   return (
     <section>
-      <div className="mv6 w-80-ns w-90 center">
+      <div>
         <OrderHeader
           orderInfo={order}
           splitOrder={splitOrder}

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,5 +1,5 @@
 {
   "order-placed": {
-    "blocks": ["order-placed-top"]
+    "blocks": ["order-placed-top", "promotion-banner"]
   }
 }

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -1,7 +1,7 @@
 {
   "order-placed": {
     "component": "OrderPlaced",
-    "allowed": ["order-placed-top"]
+    "allowed": ["order-placed-top", "promotion-banner"]
   },
   "order-placed-top": {
     "allowed": ["order-placed-extension"]


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `PromotionBanner` to `orderPlaced` to promote the installation of the web app and show prompt.

#### What problem is this solving?
In the store settings, you can choose to show the [install prompt](https://developers.google.com/web/fundamentals/app-install-banners/promoting-install-mobile) when the first purchase is maded. 

#### How should this be manually tested?
[Workspace](https://thay--storecomponents.myvtex.com/checkout/orderPlaced/?og=949500478939)

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
