### PR TITLE
Add page block to the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Add the page block to the docs.
 
 ## [2.0.1] - 2020-02-28
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -160,6 +160,14 @@ _Note: this is the default `order-placed` layout implementation._
 }
 ```
 
+Make sure you have the Order Placed page defined in your theme:
+
+```json
+  "store.orderplaced": {
+    "children": ["order-placed"]
+  },
+```
+
 ## Blocks
 
 ### `order-placed`


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change docs to make sure users don't forget to define de store.orderplaced in their theme.


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
