### PR TITLE
Export the order and order group contexts as hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-### Fixed
-
-- The order context is exported to be accessed from other custom projects.
+### Added
+- Export the `useOrder` and `useOrderGroup` hooks.
 
 ## [2.1.0] - 2020-03-10
-
 ### Added
-
 - `footer` extension point.
 
 ## [2.0.2] - 2020-02-28
-
 ### Fixed
-
 - Add the page block to the docs.
 
 ## [2.0.1] - 2020-02-28
-
 ### Fixed
-
 - English translation.
 
 ## [2.0.0] - 2020-02-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,26 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- The order context is exported to be accessed from other custom projects.
+
 ## [2.1.0] - 2020-03-10
+
 ### Added
+
 - `footer` extension point.
 
 ## [2.0.2] - 2020-02-28
+
 ### Fixed
+
 - Add the page block to the docs.
 
 ## [2.0.1] - 2020-02-28
+
 ### Fixed
+
 - English translation.
 
 ## [2.0.0] - 2020-02-03

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,9 @@
 📢 Use this project, [contribute](https://github.com/vtex-apps/order-placed) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # Order Placed
@@ -14,6 +17,7 @@
   - [`order-placed`](#order-placed-1)
   - [`op-section`](#op-section)
   - [`op-header`](#op-header)
+  - [`op-footer`](#op-footer)
   - [`op-confirmation-icon`](#op-confirmation-icon)
   - [`op-confirmation-title`](#op-confirmation-title)
   - [`op-confirmation-message`](#op-confirmation-message)
@@ -32,8 +36,10 @@
   - [`op-order-delivery-packages`](#op-order-delivery-packages)
   - [`op-order-pickup-packages`](#op-order-pickup-packages)
   - [`op-order-total`](#op-order-total)
+- [API](#api)
 - [Customization](#customization)
 - [Contributing](#contributing)
+- [Contributors ✨](#contributors)
 
 <!-- /code_chunk_output -->
 
@@ -597,6 +603,28 @@ Renders an order delivery packages information and product list. Must be placed 
 | ---------------------------------------------- |
 | ![op-order-total](./images/op-order-total.png) |
 
+## API
+
+The `order-placed` app exports two hooks to allow customization using the current order data: `useOrderGroup` and `useOrder`.
+
+`useOrderGroup`: used to get the data of the current order group. An order group is the collection of all orders created by an users's purchase.
+
+```js
+import { useOrderGroup } from 'vtex.order-placed'
+
+//...
+const orderGroup = useOrderGroup()
+```
+
+`useOrder`: used to get the data of the current order being accessed in the order loop.
+
+```js
+import { useOrder } from 'vtex.order-placed'
+
+//...
+const order = useOrder()
+```
+
 ## Customization
 
 In order to apply CSS customizations in this and other blocks, follow the instructions given in the recipe on [Using CSS Handles for store customization](https://vtex.io/docs/recipes/style/using-css-handles-for-store-customization).
@@ -701,6 +729,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 <!-- markdownlint-disable -->
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/docs/README.md
+++ b/docs/README.md
@@ -610,7 +610,7 @@ The `order-placed` app exports two hooks to allow customization using the curren
 `useOrderGroup`: used to get the data of the current order group. An order group is the collection of all orders created by an users's purchase.
 
 ```js
-import { useOrderGroup } from 'vtex.order-placed'
+import { useOrderGroup } from 'vtex.order-placed/OrderGroupContext'
 
 //...
 const orderGroup = useOrderGroup()
@@ -619,7 +619,7 @@ const orderGroup = useOrderGroup()
 `useOrder`: used to get the data of the current order being accessed in the order loop.
 
 ```js
-import { useOrder } from 'vtex.order-placed'
+import { useOrder } from 'vtex.order-placed/OrderContext'
 
 //...
 const order = useOrder()

--- a/react/OrderContext.tsx
+++ b/react/OrderContext.tsx
@@ -1,3 +1,3 @@
-import { useOrder, OrderContext } from './components/OrderContext'
+import { useOrder } from './components/OrderContext'
 
-export default { useOrder, OrderContext }
+export default { useOrder }

--- a/react/OrderContext.tsx
+++ b/react/OrderContext.tsx
@@ -1,0 +1,3 @@
+import { useOrder, OrderContext } from './components/OrderContext'
+
+export default { useOrder, OrderContext }

--- a/react/OrderGroupContext.tsx
+++ b/react/OrderGroupContext.tsx
@@ -1,0 +1,6 @@
+import {
+  OrderGroupContext,
+  useOrderGroup,
+} from './components/OrderGroupContext'
+
+export default { OrderGroupContext, useOrderGroup }

--- a/react/OrderGroupContext.tsx
+++ b/react/OrderGroupContext.tsx
@@ -1,6 +1,3 @@
-import {
-  OrderGroupContext,
-  useOrderGroup,
-} from './components/OrderGroupContext'
+import { useOrderGroup } from './components/OrderGroupContext'
 
-export default { OrderGroupContext, useOrderGroup }
+export default { useOrderGroup }


### PR DESCRIPTION
#### What is the purpose of this pull request?

We need the context of the command that is being used by the vtex.order-placed@2.X component to be exported in order to access it from our own component exito.order-placed@3.X,
which shows how son vtex.order-placed@2.X with business customizations such as: plastic bag tax, accumulated colombian points and validation of payment with a exito card using an otp code.
For these customizations we need to use the information coming from the context of the vtex.order-placed@2.X command.

#### What problem is this solving?

Resolve to be able to obtain the necessary information to carry out these customizations.

#### Screenshots or example usage
![Example](https://user-images.githubusercontent.com/46934781/77808963-9c9b9c00-705b-11ea-984f-8f424cd2210b.PNG)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
