### PR TITLE
Replace main tag with role=main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `main` tag not working properly in IE 11.
+- Possible duped keys in `OrderTotal`.
 
 ## [2.2.3] - 2020-05-15
 

--- a/react/OrderTotal.tsx
+++ b/react/OrderTotal.tsx
@@ -27,12 +27,15 @@ const OrderTotal: FC = () => {
       <ul
         className={`${handles.totalList} list pa0 mt8 w-100 w-60-l c-muted-1`}
       >
-        {newTotals.map(total => {
-          if (total.value === 0) return null
+        {newTotals.map((total, i) => {
+          if (total.value === 0) {
+            return null
+          }
+
           return (
             <li
               className={`${handles.totalListItem} pv3 flex justify-between items-center`}
-              key={total.id}
+              key={`${total.id}_${i}`}
             >
               <span className={`${handles.totalListItemLabel} flex`}>
                 <TranslateTotalizer totalizer={total} />

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -73,7 +73,8 @@ const OrderPlaced: FC = () => {
 
           <ExtensionPoint id="op-header" />
 
-          <main
+          <div
+            role="main"
             className={`${handles.orderPlacedMainWrapper} mv6 w-80-ns w-90 center`}
           >
             <OrderList />
@@ -85,7 +86,7 @@ const OrderPlaced: FC = () => {
                 onDismiss={() => setInstallDismissed(true)}
               />
             )}
-          </main>
+          </div>
 
           <ExtensionPoint id="op-footer" />
         </div>


### PR DESCRIPTION
#### What problem is this solving?

IE 11 doesn't support the `main` tag and React is complaining about it. This PR also fixes a possible duped `key`.

#### How should this be manually tested?

- Open https://mototest--motorolasandbox.myvtex.com/checkout/orderPlaced/?og=1031982999821 in a IE 11

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
