### PR TITLE
Add parentItemIndex in GraphQL query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `parentItemIndex` field in GraphQL query.
+
 ## [2.4.3] - 2020-10-21
 
 ### Fixed

--- a/react/graphql/getOrderGroup.graphql
+++ b/react/graphql/getOrderGroup.graphql
@@ -26,6 +26,7 @@ query getOrderGroup($orderGroup: String) {
           price
           listPrice
           isGift
+          parentItemIndex
           quantity
           attachments {
             content
@@ -112,6 +113,7 @@ query getOrderGroup($orderGroup: String) {
           price
           listPrice
           isGift
+          parentItemIndex
           quantity
           attachments {
             content
@@ -198,6 +200,7 @@ query getOrderGroup($orderGroup: String) {
           price
           listPrice
           isGift
+          parentItemIndex
           quantity
           attachments {
             content
@@ -268,6 +271,7 @@ query getOrderGroup($orderGroup: String) {
         price
         listPrice
         isGift
+        parentItemIndex
         quantity
         attachments {
           content
@@ -358,6 +362,7 @@ query getOrderGroup($orderGroup: String) {
         price
         listPrice
         isGift
+        parentItemIndex
         quantity
         attachments {
           content
@@ -444,6 +449,7 @@ query getOrderGroup($orderGroup: String) {
         price
         listPrice
         isGift
+        parentItemIndex
         quantity
         attachments {
           content
@@ -530,6 +536,7 @@ query getOrderGroup($orderGroup: String) {
         price
         listPrice
         isGift
+        parentItemIndex
         quantity
         attachments {
           content


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add new field so it's possible to identify items that have assembly options.

#### How should this be manually tested?

https://orderplacedparent--storecomponents.myvtex.com/checkout/orderPlaced/?og=1082982841447

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/284515/102090102-cec47800-3dfb-11eb-9884-c5c239d2742d.png)

#### Depends on

https://github.com/vtex/order-placed-graphql/pull/24