### PR TITLE
Removing assemblies from the items count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- Removing assemblies from the items count
+  
+### Added
+
 - `parentItemIndex` field in GraphQL query.
 
 ## [2.4.3] - 2020-10-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Removing assemblies from the items count
+
 ## [2.6.0] - 2020-12-17
 
 ### Added
@@ -23,10 +27,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.5.0] - 2020-12-15
 
-### Added
-
-- Removing assemblies from the items count
-  
 ### Added
 
 - `parentItemIndex` field in GraphQL query.

--- a/react/OrderTotal.tsx
+++ b/react/OrderTotal.tsx
@@ -19,7 +19,12 @@ const CSS_HANDLES = [
 const OrderTotal: FC = () => {
   const { items, totals, value: totalValue } = useOrder()
   const handles = useCssHandles(CSS_HANDLES)
-  const numItems = items.reduce((acc, item) => acc + item.quantity, 0)
+  const numItems = items.reduce((acc, item) => {
+    if (item.parentItemIndex === null) {
+      return acc + item.quantity
+    }
+    return acc
+  }, 0)
   const [newTotals, taxes] = getTotals(totals)
 
   return (


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removing assemblies from the items count.
Reference: https://github.com/vtex-apps/minicart/pull/260

#### What problem is this solving?

The wrong count number on the screen

#### How should this be manually tested?

[Workspace](https://mcdon125--acctglobal.myvtex.com/checkout/orderPlaced/?og=1082931550390)

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
