### PR TITLE
Add productId property to getOrderGroup query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- `productId` property to `getOrderGroup` query
 
 ## [2.6.2] - 2020-12-22
 

--- a/react/graphql/getOrderGroup.graphql
+++ b/react/graphql/getOrderGroup.graphql
@@ -23,6 +23,7 @@ query getOrderGroup($orderGroup: String) {
           id
           skuName
           name
+          productId
           price
           listPrice
           isGift
@@ -110,6 +111,7 @@ query getOrderGroup($orderGroup: String) {
           id
           skuName
           name
+          productId
           price
           listPrice
           isGift
@@ -197,6 +199,7 @@ query getOrderGroup($orderGroup: String) {
           id
           skuName
           name
+          productId
           price
           listPrice
           isGift
@@ -268,6 +271,7 @@ query getOrderGroup($orderGroup: String) {
         id
         skuName
         name
+        productId
         price
         listPrice
         isGift
@@ -359,6 +363,7 @@ query getOrderGroup($orderGroup: String) {
         id
         skuName
         name
+        productId
         price
         listPrice
         isGift
@@ -446,6 +451,7 @@ query getOrderGroup($orderGroup: String) {
         id
         skuName
         name
+        productId
         price
         listPrice
         isGift
@@ -533,6 +539,7 @@ query getOrderGroup($orderGroup: String) {
         id
         skuName
         name
+        productId
         price
         listPrice
         isGift

--- a/react/package.json
+++ b/react/package.json
@@ -30,13 +30,13 @@
     "vtex.order-details": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-details@1.1.1/public/@types/vtex.order-details",
     "vtex.order-placed-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.13.0/public/@types/vtex.order-placed-graphql",
     "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.6.1/public/@types/vtex.pixel-manager",
-    "vtex.profile-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.3.3/public/_types/react",
+    "vtex.profile-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.4.0/public/_types/react",
     "vtex.pwa-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pwa-components@0.4.1/public/@types/vtex.pwa-components",
-    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime",
+    "vtex.render-runtime": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime",
     "vtex.responsive-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-layout@0.1.2/public/@types/vtex.responsive-layout",
     "vtex.responsive-values": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-values@0.4.0/public/@types/vtex.responsive-values",
     "vtex.shipping-estimate-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator",
-    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.75.0/public/@types/vtex.store-resources",
+    "vtex.store-resources": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.75.1/public/@types/vtex.store-resources",
     "vtex.styleguide": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide",
     "vtex.totalizer-translator": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.totalizer-translator@2.2.0/public/_types/react"
   }

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -46,6 +46,7 @@ interface OrderItem {
   attachments: Attachment[]
   skuName: string
   name: string
+  productId: string
   price: number
   listPrice: number
   bundleItems: Bundle[]

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5141,17 +5141,17 @@ verror@1.10.0:
   version "1.6.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.6.1/public/@types/vtex.pixel-manager#a9cf803f14aa60290a622155fb59e5243c4197bc"
 
-"vtex.profile-form@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.3.3/public/_types/react":
+"vtex.profile-form@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.4.0/public/_types/react":
   version "0.0.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.3.3/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.4.0/public/_types/react#fa7a0347e046eab3dd768998fc9252b2c0dd5aef"
 
 "vtex.pwa-components@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pwa-components@0.4.1/public/@types/vtex.pwa-components":
   version "0.4.1"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pwa-components@0.4.1/public/@types/vtex.pwa-components#a576d7799f8e4c5c4db1ff539dcebe0cf95dbbd9"
 
-"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime":
-  version "8.126.4"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.4/public/@types/vtex.render-runtime#40d7ad8a7b04c50e61ff84a1089dcf7045efd548"
+"vtex.render-runtime@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime":
+  version "8.126.6"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.render-runtime@8.126.6/public/@types/vtex.render-runtime#78ae3da048ec823ab104425aef14e66165ed1303"
 
 "vtex.responsive-layout@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.responsive-layout@0.1.2/public/@types/vtex.responsive-layout":
   version "0.1.2"
@@ -5165,9 +5165,9 @@ verror@1.10.0:
   version "2.2.2"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.shipping-estimate-translator@2.2.2/public/@types/vtex.shipping-estimate-translator#0daa482f261e7c40a06c27be07e9e5b9d70cf063"
 
-"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.75.0/public/@types/vtex.store-resources":
-  version "0.75.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.75.0/public/@types/vtex.store-resources#0741ba5f5430217a41f72a06b2a6bc3565be188e"
+"vtex.store-resources@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.75.1/public/@types/vtex.store-resources":
+  version "0.75.1"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.store-resources@0.75.1/public/@types/vtex.store-resources#6374ad0729cb1ee5b06f7e094b4bdbeb1e2679d0"
 
 "vtex.styleguide@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.styleguide@9.134.1/public/@types/vtex.styleguide":
   version "9.134.1"


### PR DESCRIPTION
#### What is the purpose of this pull request?
App Store has a component (`AppPrice`) to show the app price. This component is rendered on the Product and Checkout pages. `AppPrice` does a query to `app-store-api` to get the price but this query has a `productId` as a variable.

```
const { data, loading } = useQuery<AppPriceQuery, QueryAppPriceArgs>(
    APP_PRICE,
    {
      variables: { productId },
    }
  )
```

I would like to add the `productId` to the `getOrderGroup` query so then I will be able to consume this value from the `OrderGroupContext`.

#### What problem is this solving? 

`productId` property to `getOrderGroup` query

#### How should this be manually tested?
You must buy an app to `pilateslovers` account.  Click on `Get app` button and fill the input with `pilateslovers` value. 
You will log in and then you will be redirected to the product page again. Go to checkout clicking on `Get App` button again. Finish the free purchase and go to the order placed page.  
Or, you can check the order placed page:  [workspace](https://pedrocheckout--extensions.myvtex.com/checkout/orderPlaced/?og=1103261289053)
#### Screenshots or example usage

<img width="638" alt="Screen Shot 2021-01-14 at 10 48 34 AM" src="https://user-images.githubusercontent.com/32311264/104599142-2c93ec00-5656-11eb-9791-80044637a630.png">

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
