### PR TITLE
Fix/product subtotal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Product Subtotal in `ProductList/Product.tsx`, adding unitMultiplier in product subtotal
+
 ## [2.8.0] - 2021-01-19
 
 ### Added

--- a/react/components/ProductList/Product.tsx
+++ b/react/components/ProductList/Product.tsx
@@ -32,11 +32,7 @@ const Product: FC<Props> = ({ product }) => {
   } = product
   const handles = useCssHandles(CSS_HANDLES)
   const showMeasurementUnit = unitMultiplier !== 1 || measurementUnit !== 'un'
-  const productSubtotal = useMemo(() => price * quantity * unitMultiplier, [
-    price,
-    quantity,
-    unitMultiplier,
-  ])
+  const productSubtotal = price * quantity * unitMultiplier
 
   return (
     <div className={`${handles.productWrapper} w-100 flex-m tc tl-m`}>

--- a/react/components/ProductList/Product.tsx
+++ b/react/components/ProductList/Product.tsx
@@ -69,7 +69,7 @@ const Product: FC<Props> = ({ product }) => {
         </small>
       </div>
       <div className={`${handles.productPrice} ml-auto mt3 mt0-m`}>
-        <FormattedPrice value={subtotalProduct} />
+        <FormattedPrice value={productSubtotal} />
       </div>
     </div>
   )

--- a/react/components/ProductList/Product.tsx
+++ b/react/components/ProductList/Product.tsx
@@ -32,7 +32,11 @@ const Product: FC<Props> = ({ product }) => {
   } = product
   const handles = useCssHandles(CSS_HANDLES)
   const showMeasurementUnit = unitMultiplier !== 1 || measurementUnit !== 'un'
-  const productSubtotal = useMemo( () => (price * quantity * unitMultiplier) ,[price, quantity, unitMultiplier])
+  const productSubtotal = useMemo(() => price * quantity * unitMultiplier, [
+    price,
+    quantity,
+    unitMultiplier,
+  ])
 
   return (
     <div className={`${handles.productWrapper} w-100 flex-m tc tl-m`}>

--- a/react/components/ProductList/Product.tsx
+++ b/react/components/ProductList/Product.tsx
@@ -32,7 +32,7 @@ const Product: FC<Props> = ({ product }) => {
   } = product
   const handles = useCssHandles(CSS_HANDLES)
   const showMeasurementUnit = unitMultiplier !== 1 || measurementUnit !== 'un'
-  const subtotalProduct = useMemo( () => (price * quantity * unitMultiplier) ,[price, quantity, unitMultiplier])
+  const productSubtotal = useMemo( () => (price * quantity * unitMultiplier) ,[price, quantity, unitMultiplier])
 
   return (
     <div className={`${handles.productWrapper} w-100 flex-m tc tl-m`}>

--- a/react/components/ProductList/Product.tsx
+++ b/react/components/ProductList/Product.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import React, { FC, useMemo } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ProductImage } from 'vtex.order-details'
 import { useCssHandles } from 'vtex.css-handles'
@@ -32,6 +32,7 @@ const Product: FC<Props> = ({ product }) => {
   } = product
   const handles = useCssHandles(CSS_HANDLES)
   const showMeasurementUnit = unitMultiplier !== 1 || measurementUnit !== 'un'
+  const subtotalProduct = useMemo( () => (price * quantity * unitMultiplier) ,[price, quantity, unitMultiplier])
 
   return (
     <div className={`${handles.productWrapper} w-100 flex-m tc tl-m`}>
@@ -68,7 +69,7 @@ const Product: FC<Props> = ({ product }) => {
         </small>
       </div>
       <div className={`${handles.productPrice} ml-auto mt3 mt0-m`}>
-        <FormattedPrice value={price * quantity} />
+        <FormattedPrice value={subtotalProduct} />
       </div>
     </div>
   )

--- a/react/components/ProductList/Product.tsx
+++ b/react/components/ProductList/Product.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useMemo } from 'react'
+import React, { FC } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { ProductImage } from 'vtex.order-details'
 import { useCssHandles } from 'vtex.css-handles'


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the product subtotal when the user see in order placed

#### What problem is this solving?
The subtotal of the product is made multiplying the product value by the unity quantity (product * quantity), when it should be product * quantity * unitMultiplier

#### How should this be manually tested?

Go into this workspace

https://iespinoza--ametllerorigen.myvtex.com/checkout/orderPlaced?og=1104662770774&__bindingAddress=www.ametllerorigen.com/ca/

Multiply the product value by the product quantity and unit multiplier, see if the result showed in top-right of the product is right loke below: 

![image](https://user-images.githubusercontent.com/13649073/106207300-4aa63400-61a0-11eb-9872-987ca256ba9c.png)

2.25 * 3 * 0.15 
1.99 * 1 * 1

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

![](https://media.giphy.com/media/t8IKNElbi8PyU/giphy.gif)
