### PR TITLE
Added hideTax prop on OrderTotal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `hideTax` prop on OrderTotal
+
 ## [2.8.2] - 2021-03-03
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -587,6 +587,12 @@ Renders an order delivery packages information and product list. Must be placed 
 
 **Composition:** none.
 
+**Props:**
+
+| Prop name   | Type      | Description                                         | Default value |
+| ----------- | --------- | --------------------------------------------------- | ------------- |
+| `hideTax`   | `boolean` | Hide the taxes                                      | `false`       |
+
 **CSS Handles:**
 
 | CSS Handles          | Description                                 |

--- a/react/OrderTotal.tsx
+++ b/react/OrderTotal.tsx
@@ -20,9 +20,7 @@ interface Props {
   hideTax?: boolean
 }
 
-const OrderTotal: FC<Props> = ({
-  hideTax = false
-}) => {
+const OrderTotal: FC<Props> = ({ hideTax = false }) => {
   const { items, totals, value: totalValue } = useOrder()
   const handles = useCssHandles(CSS_HANDLES)
   const numItems = items.reduce((acc, item) => {

--- a/react/OrderTotal.tsx
+++ b/react/OrderTotal.tsx
@@ -16,7 +16,13 @@ const CSS_HANDLES = [
   'totalListItemValue',
 ]
 
-const OrderTotal: FC = () => {
+interface Props {
+  hideTax?: boolean
+}
+
+const OrderTotal: FC<Props> = ({
+  hideTax = false
+}) => {
   const { items, totals, value: totalValue } = useOrder()
   const handles = useCssHandles(CSS_HANDLES)
   const numItems = items.reduce((acc, item) => {
@@ -33,7 +39,7 @@ const OrderTotal: FC = () => {
         className={`${handles.totalList} list pa0 mt8 w-100 w-60-l c-muted-1`}
       >
         {newTotals.map((total, i) => {
-          if (total.value === 0) {
+          if (total.value === 0 || (total.id === 'Tax' && hideTax)) {
             return null
           }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
The prop added (hideTax) will hide the taxes from the confirmation page for when the client doesn't want them there

#### What problem is this solving?
It was requested by a client of us to not have the TVA (Taxes) shown on the confirmation page

#### How should this be manually tested?

1. Link a store theme with the default order-placed block
2. Add the hideTax prop to op-order-total and set it to true
3. Link the order-placed app from this branch on the same workspace

#### Screenshots or example usage

![withoutTax](https://user-images.githubusercontent.com/71461884/110646963-1b7fdb00-81c0-11eb-9a59-54238a2cd933.png)
![withHideTax](https://user-images.githubusercontent.com/71461884/110646967-1c187180-81c0-11eb-9f62-dcc6a02dc6fe.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Requires change to documentation, which has been updated accordingly.
