### PR TITLE
Add modifier to totalListItem CSS Handle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+
+- Modifier to `totalListItem` CSS Handle, making it possible to hide one specific totalizer.
 
 ## [2.10.0] - 2021-04-29
 

--- a/react/OrderTotal.tsx
+++ b/react/OrderTotal.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { FormattedMessage } from 'react-intl'
 import TranslateTotalizer from 'vtex.totalizer-translator/TranslateTotalizer'
-import { useCssHandles } from 'vtex.css-handles'
+import { applyModifiers, useCssHandles } from 'vtex.css-handles'
 
 import FormattedPrice from './components/FormattedPrice'
 import { useOrder } from './components/OrderContext'
@@ -14,7 +14,7 @@ const CSS_HANDLES = [
   'totalListItem',
   'totalListItemLabel',
   'totalListItemValue',
-]
+] as const
 
 const OrderTotal: FC = () => {
   const { items, totals, value: totalValue } = useOrder()
@@ -39,7 +39,10 @@ const OrderTotal: FC = () => {
 
           return (
             <li
-              className={`${handles.totalListItem} pv3 flex justify-between items-center`}
+              className={`${applyModifiers(
+                handles.totalListItem,
+                total.id
+              )} pv3 flex justify-between items-center`}
               key={`${total.id}_${i}`}
             >
               <span className={`${handles.totalListItemLabel} flex`}>


### PR DESCRIPTION
#### What is the purpose of this pull request?

Make it possible to make a CSS selector that targets just one totalizer.

#### What problem is this solving?

Fixes #143 

#### How should this be manually tested?

https://breno2--storecomponents.myvtex.com/checkout/orderPlaced/?og=1119571095058

#### Screenshots or example usage
![image](https://user-images.githubusercontent.com/284515/115467930-ab299800-a208-11eb-9a5a-3d770d3a22bb.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
