### PR TITLE
Fix to show product price after discount for each item in the list

### DIFF
--- a/react/components/ProductList/Product.tsx
+++ b/react/components/ProductList/Product.tsx
@@ -27,14 +27,14 @@ const Product: FC<Props> = ({ product }) => {
     imageUrl,
     measurementUnit,
     name,
-    price,
+    sellingPrice,
     quantity,
     unitMultiplier,
     isGift,
   } = product
   const handles = useCssHandles(CSS_HANDLES)
   const showMeasurementUnit = unitMultiplier !== 1 || measurementUnit !== 'un'
-  const productSubtotal = price * quantity * unitMultiplier
+  const productSubtotal = sellingPrice * quantity * unitMultiplier
 
   return (
     <div className={`${handles.productWrapper} w-100 flex-m tc tl-m`}>

--- a/react/graphql/getOrderGroup.graphql
+++ b/react/graphql/getOrderGroup.graphql
@@ -24,7 +24,7 @@ query getOrderGroup($orderGroup: String) {
           skuName
           name
           productId
-          price
+          sellingPrice
           listPrice
           isGift
           parentItemIndex

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -47,7 +47,7 @@ interface OrderItem {
   skuName: string
   name: string
   productId: string
-  price: number
+  sellingPrice: number
   listPrice: number
   bundleItems: Bundle[]
   isGift: boolean


### PR DESCRIPTION
#### What is the purpose of this pull request?
‘price’ attribute is used in product list instead of ‘sellingPrice’. So user is not able to see the discounted price(eg: in case of subscription orders) in order confirmation page for a product. Regular price is always displayed in order confirmation page even when their is a discount for a product.

#### What problem is this solving?
Displays correct price for a product always.

#### How should this be manually tested?
It can be tested by placing any upsell /subscription order(with discounts).

#### Screenshots or example usage
![IncorrectPrice](https://user-images.githubusercontent.com/86110961/130065910-1cc7183d-9dd6-434b-bfc9-558f48ce1f00.png)
![IncorrectPrice1](https://user-images.githubusercontent.com/86110961/130065928-e4ef9a68-0a49-4a45-90e0-ca936a437bad.png)


#### Types of changes
 Bug fix (non-breaking change which fixes an issue)
