### PR TITLE
removing destruct and passing array in map

### DIFF
--- a/react/OrderPayment.tsx
+++ b/react/OrderPayment.tsx
@@ -12,17 +12,17 @@ const OrderPayment = () => {
   const currency = useCurrency()
   const handles = useCssHandles(CSS_HANDLES)
 
-  const [{ payments, transactionId }] = order.paymentData.transactions
+  const transactions = order.paymentData.transactions
 
   return (
     <div
       className={`${handles.orderPaymentWrapper} flex flex-column flex-row-m`}
     >
-      {payments.map((payment, idx) => (
+      {transactions.map((payment, idx) => (
         <div key={idx} className={`${handles.orderPaymentItem} pb8-s mr9-m`}>
           <PaymentMethod
-            payment={payment}
-            transactionId={transactionId}
+            payment={payment.payments[0]}
+            transactionId={payment.transactionId}
             currency={currency}
           />
         </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
To show correctly the payment methods when the user pays with 2 methods ex: cash and gift card

#### What problem is this solving?
order.paymentData.transactions returns an array, the way it is done today is only showing the first element. If we select gift card and cash, only shows gift card OR cash

#### How should this be manually tested?
On payment, select a gift card and select one other method of payment (in the test, i tested with cash)

#### Screenshots or example usage

Before fix:
![before](https://user-images.githubusercontent.com/47106171/130834016-8e996ded-1a8c-4d7e-827e-d8008c8408dc.png)

After fix:
![after](https://user-images.githubusercontent.com/47106171/130833973-e324f0f3-c726-444d-a627-5e20ea41dca1.png)


#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
