### PR TITLE
Add/page title from cms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Title now considers page title, when exists, instead of only the one in messages
+
 ## [2.16.0] - 2022-03-17
 
 ### Added
@@ -44,10 +48,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.12.1] - 2021-09-13 [DEPRECATED]
 
 ## [2.12.0] - 2021-05-26
+
 ### Added
 
 - CSS Handle: `packageReceiverName`
+
 ## [2.11.0] - 2021-04-29
+
 ### Added
 
 - Modifier to `totalListItem` CSS Handle, making it possible to hide one specific totalizer.
@@ -74,6 +81,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.8.3] - 2021-04-07
 
 ### Added
+
 - Add _FREE_ as a price tag for all products that are gifts
 
 ## [2.8.2] - 2021-03-03

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -57,6 +57,8 @@ const OrderPlaced: FC = () => {
   }
 
   const { orderGroup }: { orderGroup: OrderGroup } = data
+  const title = runtime.route.title || formatMessage(messages.title)
+
   const { promptOnCustomEvent } = settings
 
   return (
@@ -65,7 +67,7 @@ const OrderPlaced: FC = () => {
         value={orderGroup.orders[0].storePreferencesData.currencyCode}
       >
         <Helmet>
-          <title>{formatMessage(messages.title)}</title>
+          <title>{title}</title>
         </Helmet>
 
         <div className={`${handles.orderPlacedWrapper} pt9 sans-serif`}>

--- a/react/index.tsx
+++ b/react/index.tsx
@@ -57,7 +57,7 @@ const OrderPlaced: FC = () => {
   }
 
   const { orderGroup }: { orderGroup: OrderGroup } = data
-  const title = runtime.route.title || formatMessage(messages.title)
+  const title = runtime.route?.title || formatMessage(messages.title)
 
   const { promptOnCustomEvent } = settings
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
Consider page title from CMS when exists instead of only the title from messages

#### What problem is this solving?
Clients can't see their changes of title inside order placed

#### How should this be manually tested?

[Before](https://master--tapitdev.myvtex.com/checkout/orderPlaced/?og=1179830462737)

Read only from message
![image](https://user-images.githubusercontent.com/13649073/144937020-8a11c12f-2b0c-4221-b369-57d3be82dde3.png)

[After](https://ordertitle--tapitdev.myvtex.com/checkout/orderPlaced/?og=1179830462737)

Read from pages and message
![image](https://user-images.githubusercontent.com/13649073/144936916-0f7e9045-f647-4812-8e01-bac0f8873c88.png)


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
