### PR TITLE
✨ Add field `paymentOrigin` to `getOrderGroup` graphql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Field `paymentOrigin` to `getOrderGroup` graphql.
+
 ## [2.16.0] - 2022-03-17
 
 ### Added

--- a/react/graphql/getOrderGroup.graphql
+++ b/react/graphql/getOrderGroup.graphql
@@ -328,6 +328,7 @@ query getOrderGroup($orderGroup: String) {
             id
             paymentSystem
             paymentSystemName
+            paymentOrigin
             value
             installments
             lastDigits

--- a/react/package.json
+++ b/react/package.json
@@ -29,7 +29,7 @@
     "vtex.flex-layout": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.flex-layout@0.19.0/public/@types/vtex.flex-layout",
     "vtex.order-details": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-details@1.6.0/public/@types/vtex.order-details",
     "vtex.order-placed": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed@2.12.0/public/@types/vtex.order-placed",
-    "vtex.order-placed-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.16.0/public/@types/vtex.order-placed-graphql",
+    "vtex.order-placed-graphql": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.17.0/public/@types/vtex.order-placed-graphql",
     "vtex.pixel-manager": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pixel-manager@1.8.0/public/@types/vtex.pixel-manager",
     "vtex.profile-form": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.profile-form@3.9.1/public/@types/vtex.profile-form",
     "vtex.pwa-components": "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.pwa-components@0.4.1/public/@types/vtex.pwa-components",

--- a/react/typings/global.d.ts
+++ b/react/typings/global.d.ts
@@ -128,6 +128,7 @@ interface Payment {
   id: string
   paymentSystem: string
   paymentSystemName: string
+  paymentOrigin: string | null
   value: number
   lastDigits: string | null
   group: string

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5133,9 +5133,9 @@ verror@1.10.0:
   version "1.6.0"
   resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-details@1.6.0/public/@types/vtex.order-details#c0d92d3784984c58667df5b1d5c88ae58c722cec"
 
-"vtex.order-placed-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.16.0/public/@types/vtex.order-placed-graphql":
-  version "1.16.0"
-  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.16.0/public/@types/vtex.order-placed-graphql#5895b2640912eae5a5ca67bb2273a10bc7a424fb"
+"vtex.order-placed-graphql@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.17.0/public/@types/vtex.order-placed-graphql":
+  version "1.17.0"
+  resolved "http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed-graphql@1.17.0/public/@types/vtex.order-placed-graphql#da9a271064812cec1bc992d59eb1406c2e2508e0"
 
 "vtex.order-placed@http://vtex.vtexassets.com/_v/public/typings/v1/vtex.order-placed@2.12.0/public/@types/vtex.order-placed":
   version "2.12.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
ATTS

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
Since the Payments team is implementing a native solution for Google Pay, we must inform that the payment was made with Google Pay. This info is available at the prop `paymentOrigin` that is going to be provided at the end point `/api/checkout/pub/orders/order-group/${orderGroup}`.

#### How should this be manually tested?
* Finish a purchase at [this store](https://krro--storecomponents.myvtex.com/checkout) with credit card

#### Screenshots or example usage
Order finished with credit card - displaying payment method name
![order-placed-paymentMethodName](https://user-images.githubusercontent.com/4183629/224826385-275508e9-d8b9-4ddb-a352-de290eda3daf.png)

Order finished with Google Pay - displaying payment method and wallet name
![order-placed-paymentOrigin](https://user-images.githubusercontent.com/4183629/224826389-dcc0ad5b-d7c8-4726-a18b-bc3afc45fc31.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
