### PR TITLE
Fix barcode vulnerability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix bank invoice barcode smart checkout vulnerability.
+
 ## [2.17.0] - 2023-03-14
 
 ### Added
@@ -50,10 +54,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.12.1] - 2021-09-13 [DEPRECATED]
 
 ## [2.12.0] - 2021-05-26
+
 ### Added
 
 - CSS Handle: `packageReceiverName`
+
 ## [2.11.0] - 2021-04-29
+
 ### Added
 
 - Modifier to `totalListItem` CSS Handle, making it possible to hide one specific totalizer.
@@ -80,6 +87,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.8.3] - 2021-04-07
 
 ### Added
+
 - Add _FREE_ as a price tag for all products that are gifts
 
 ## [2.8.2] - 2021-03-03

--- a/react/components/BankInvoice/BarCode.tsx
+++ b/react/components/BankInvoice/BarCode.tsx
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl'
 import { Button } from 'vtex.styleguide'
 import { useCssHandles } from 'vtex.css-handles'
 
+import { getLoginUrl } from '../../utils'
+
 interface Props {
   barCodeNumber: string
 }
@@ -16,6 +18,8 @@ const CSS_HANDLES = [
 
 const BarCode: FC<Props> = ({ barCodeNumber }) => {
   const handles = useCssHandles(CSS_HANDLES)
+  const isEncrypted = barCodeNumber.includes('*')
+
   return (
     <div
       data-testid="bank-invoice-barcode"
@@ -26,15 +30,25 @@ const BarCode: FC<Props> = ({ barCodeNumber }) => {
       >
         {barCodeNumber}
       </div>
-      <Clipboard
-        component="div"
-        data-clipboard-text={barCodeNumber}
-        className={`${handles.barCodeCopyButtonWrapper} b--muted-4 bl-l bt bt-0-l bw1 flex flex-row-l flex-column`}
-      >
-        <Button variation="tertiary">
-          <FormattedMessage id="store/header.bankinvoice.copy" />
-        </Button>
-      </Clipboard>
+      {isEncrypted ? (
+        <div
+          className={`${handles.barCodeCopyButtonWrapper} b--muted-4 bl-l bt bt-0-l bw1 flex flex-row-l flex-column`}
+        >
+          <Button variation="tertiary" href={getLoginUrl()} target="_blank">
+            <FormattedMessage id="store/header.bankinvoice.copy" />
+          </Button>
+        </div>
+      ) : (
+        <Clipboard
+          component="div"
+          data-clipboard-text={barCodeNumber}
+          className={`${handles.barCodeCopyButtonWrapper} b--muted-4 bl-l bt bt-0-l bw1 flex flex-row-l flex-column`}
+        >
+          <Button variation="tertiary">
+            <FormattedMessage id="store/header.bankinvoice.copy" />
+          </Button>
+        </Clipboard>
+      )}
     </div>
   )
 }

--- a/react/utils/index.ts
+++ b/react/utils/index.ts
@@ -136,6 +136,12 @@ export function parseBankInvoiceUrl(url: string) {
   const isEncrypted = !!url.match(/(\*.\*.)+\*\w\*/g)
   if (!isEncrypted) return url
 
+  const loginUrl = getLoginUrl()
+
+  return loginUrl
+}
+
+export function getLoginUrl() {
   return `${get(
     window,
     '__RUNTIME__.rootPath',


### PR DESCRIPTION
#### What is the purpose of this pull request?
ATTS

#### What problem is this solving?
Currently, if an user places an order though smart checkout with bank invoice payment, the barcode is shown without requesting authentication. When the barcode is inserted into the bank app, it shows sensitive data from the buyer (like CPF), so we need to encrypt the barcode and request authentication to open it.

This PR adds the login request flow to open the barcode, and the encryption is done by [this other PR](https://github.com/vtex/sales-order-system/pull/368).

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
