### PR TITLE
change object to read pickupStoreInfo

### DIFF
--- a/react/components/PickUpHeader.tsx
+++ b/react/components/PickUpHeader.tsx
@@ -26,6 +26,8 @@ const StorePickUpHeader: FC<Props> = ({ shippingData, index, numPackages }) => {
   const multiplePickups = numPackages > 1
   const { receiverName } = shippingData.address
   const { additionalInfo } = shippingData.selectedSlaObj.pickupStoreInfo
+  const pickupStoreInfo = shippingData.selectedSlaObj.pickupStoreInfo
+
   return (
     <Fragment>
       <div
@@ -61,7 +63,7 @@ const StorePickUpHeader: FC<Props> = ({ shippingData, index, numPackages }) => {
           <FormattedMessage id="store/shipping.header.address" />
         </span>
         <div className={`${handles.packageAddressWrapper} mb5 mr10-m`}>
-          <Address address={shippingData.address} pickup={shippingData} />
+          <Address address={pickupStoreInfo.address} pickup={shippingData} />
         </div>
         <div className={`${handles.packageReceiver} c-on-base lh-copy`}>
           <p className={`${handles.packageReceiverName}`}>{receiverName}</p>


### PR DESCRIPTION
#### What is the purpose of this pull request?

The Pickup Point information is masked when the client is not logged in but the pickUp info is not PII and should not be hidden even when the client is not logged In.

#### What problem is this solving?
Unmask the pickUp Info

#### How should this be manually tested?

Beta version: `vtex.order-placed@2.17.2-beta0`

#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
