### PR TITLE
Add a guest confirmation message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- `store/header.guest-email` confirmation message for guests.
+
 ## [2.17.2] - 2023-12-12
 
 ### Fixed
+
 - Unmask data for pickup point address.
 
 ## [2.17.1] - 2023-10-11

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,9 @@
 📢 Use this project, [contribute](https://github.com/vtex-apps/order-placed) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-3-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # Order Placed
@@ -253,8 +255,8 @@ Renders the confirmation icon.
 | ------------------------- | ------------ |
 | `confirmationIconWrapper` | Icon wrapper |
 
-| Default appearance                                         |
-| ---------------------------------------------------------- |
+| Default appearance                                                                                                            |
+| ----------------------------------------------------------------------------------------------------------------------------- |
 | ![op-confirmation-icon](https://user-images.githubusercontent.com/17712401/89224372-c38c5080-d5ae-11ea-8112-9870c854e5a2.png) |
 
 ### `op-confirmation-title`
@@ -271,8 +273,8 @@ Renders the confirmation title.
 | ------------------- | ------------------------------- |
 | `confirmationTitle` | Confirmation title `h4` element |
 
-| Default appearance                                           |
-| ------------------------------------------------------------ |
+| Default appearance                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------------ |
 | ![op-confirmation-title](https://user-images.githubusercontent.com/17712401/89224442-df8ff200-d5ae-11ea-824a-25d7530249dd.png) |
 
 ### `op-confirmation-message`
@@ -281,7 +283,11 @@ Renders the confirmation message, containing the clients email.
 
 **Composition:** none.
 
-**Props:** none.
+**Props:**
+
+| Prop name            | Type      | Description                                                                                   | Default value |
+| -------------------- | --------- | --------------------------------------------------------------------------------------------- | ------------- |
+| `enableGuestMessage` | `boolean` | Flag that enables a different confirmation message (store/header.guest-email) for guest users | `false`       |
 
 **CSS Handles:**
 
@@ -289,8 +295,8 @@ Renders the confirmation message, containing the clients email.
 | --------------------- | -------------------------------- |
 | `confirmationMessage` | Confirmation message `p` element |
 
-| Default appearance                                               |
-| ---------------------------------------------------------------- |
+| Default appearance                                                                                                               |
+| -------------------------------------------------------------------------------------------------------------------------------- |
 | ![op-confirmation-message](https://user-images.githubusercontent.com/17712401/89224480-f0406800-d5ae-11ea-8602-0cb9541b0459.png) |
 
 ### `op-print-button`
@@ -303,8 +309,8 @@ Renders a button that triggers a full page print.
 
 **CSS Handles:**: none.
 
-| Default appearance                 |
-| ---------------------------------- |
+| Default appearance                                                                                                |
+| ----------------------------------------------------------------------------------------------------------------- |
 | ![op-print](https://user-images.githubusercontent.com/17712401/89224547-0817ec00-d5af-11ea-9b6a-9ae33a89daef.png) |
 
 ### `op-notices`
@@ -322,8 +328,8 @@ Renders a list of important informations relevant to the currently placed order.
 | `noticesList`    | List `ul` element           |
 | `noticeListItem` | Each list `li` item element |
 
-| Default appearance                     |
-| -------------------------------------- |
+| Default appearance                                                                                                  |
+| ------------------------------------------------------------------------------------------------------------------- |
 | ![op-notices](https://user-images.githubusercontent.com/17712401/89224594-16fe9e80-d5af-11ea-9c3e-4cfddcf76a4c.png) |
 
 ### `op-summary-section`
@@ -350,8 +356,8 @@ If a placed order is split between delivery and pickup, renders a summary of all
 | `summaryShippingSLA`   | Wrapper of the shipping SLA information     |
 | `summaryTitle`         | Box `h5` title element                      |
 
-| Default appearance                                     |
-| ------------------------------------------------------ |
+| Default appearance                                                                                                          |
+| --------------------------------------------------------------------------------------------------------------------------- |
 | ![op-summary-section](https://user-images.githubusercontent.com/17712401/89224626-267de780-d5af-11ea-80c1-7771c6dae670.png) |
 
 ### `op-bank-invoice-section`
@@ -374,8 +380,8 @@ Renders the bank invoice section if payment method chosen was bank invoice.
 | `bankInvoiceEmbedBackground` | Background of the bank invoice iframe         |
 | `bankInvoiceEmbed`           | Embed of the bank invoice PDF                 |
 
-| Default appearance                                               |
-| ---------------------------------------------------------------- |
+| Default appearance                                                                                                               |
+| -------------------------------------------------------------------------------------------------------------------------------- |
 | ![op-bank-invoice-section](https://user-images.githubusercontent.com/17712401/89224654-3695c700-d5af-11ea-9b17-98c68450370d.png) |
 
 ### `op-order`
@@ -407,8 +413,8 @@ Renders the order id number. Must be placed inside an [`op-order`](#op-order) bl
 | ------------- | ------------------------- |
 | `orderNumber` | Order number `h3` element |
 
-| Default appearance                               |
-| ------------------------------------------------ |
+| Default appearance                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------ |
 | ![op-order-number](https://user-images.githubusercontent.com/17712401/89224695-4c0af100-d5af-11ea-866e-bea733073346.png) |
 
 ### `op-order-datetime`
@@ -425,8 +431,8 @@ Renders the date and time an order was placed. Must be placed inside an [`op-ord
 | --------------- | ----------------------------------- |
 | `orderDatetime` | Order date and time `small` element |
 
-| Default appearance                                   |
-| ---------------------------------------------------- |
+| Default appearance                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------- |
 | ![op-order-datetime](https://user-images.githubusercontent.com/17712401/89224728-5a590d00-d5af-11ea-8901-7654c543d9e9.png) |
 
 ### `op-order-seller`
@@ -444,8 +450,8 @@ Renders the seller of an order. Must be placed inside an [`op-order`](#op-order)
 | `orderSoldBy` | Seller phrase `small` element |
 | `orderSeller` | Seller name `span` element    |
 
-| Default appearance                               |
-| ------------------------------------------------ |
+| Default appearance                                                                                                       |
+| ------------------------------------------------------------------------------------------------------------------------ |
 | ![op-order-seller](https://user-images.githubusercontent.com/17712401/89224779-765cae80-d5af-11ea-9320-29902e7f47dd.png) |
 
 ### `op-order-split-notice`
@@ -462,8 +468,8 @@ Renders a message with the number of packages of an order if the order was split
 | ------------- | ------------------------------ |
 | `splitNotice` | Wrapper of the message element |
 
-| Default appearance                                           |
-| ------------------------------------------------------------ |
+| Default appearance                                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------------ |
 | ![op-order-split-notice](https://user-images.githubusercontent.com/17712401/89224825-88d6e800-d5af-11ea-8801-7f2d5267da5b.png) |
 
 ### `op-order-customer`
@@ -476,8 +482,8 @@ Renders the customer information. Must be placed inside an [`op-order`](#op-orde
 
 **CSS Handles:** none.
 
-| Default appearance                                   |
-| ---------------------------------------------------- |
+| Default appearance                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------- |
 | ![op-order-customer](https://user-images.githubusercontent.com/17712401/89224880-a015d580-d5af-11ea-8314-bc223b3da0aa.png) |
 
 ### `op-order-options`
@@ -488,10 +494,10 @@ Renders the customer information. Must be placed inside an [`op-order`](#op-orde
 
 **Props:**
 
-| Prop name   | Type      | Description                                         | Default value |
-| ----------- | --------- | --------------------------------------------------- | ------------- |
-| `fullWidth` | `boolean` | Make the options wrapper take full horizontal space | `false`       |
-| `myAccountPath` | `string` | The path to redirect a user to their profile page (rendered by the `vtex.my-account` app). | `/account`       |
+| Prop name       | Type      | Description                                                                                | Default value |
+| --------------- | --------- | ------------------------------------------------------------------------------------------ | ------------- |
+| `fullWidth`     | `boolean` | Make the options wrapper take full horizontal space                                        | `false`       |
+| `myAccountPath` | `string`  | The path to redirect a user to their profile page (rendered by the `vtex.my-account` app). | `/account`    |
 
 **CSS Handles:**
 
@@ -499,8 +505,8 @@ Renders the customer information. Must be placed inside an [`op-order`](#op-orde
 | --------------------- | ----------------------------- |
 | `orderOptionsWrapper` | Wrapper of the option buttons |
 
-| Default appearance                                 |
-| -------------------------------------------------- |
+| Default appearance                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------- |
 | ![op-order-options](https://user-images.githubusercontent.com/17712401/89224923-b754c300-d5af-11ea-8b28-0efa82329e96.png) |
 
 ### `op-order-payment`
@@ -516,8 +522,8 @@ Renders the customer information. Must be placed inside an [`op-order`](#op-orde
 | `orderPaymentWrapper` | Wrapper of the payment methods list |
 | `orderPaymentItem`    | Wrapper of each payment method item |
 
-| Default appearance                                 |
-| -------------------------------------------------- |
+| Default appearance                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------- |
 | ![op-order-payment](https://user-images.githubusercontent.com/17712401/89225037-eec36f80-d5af-11ea-82af-267cb69c7d7b.png) |
 
 ### `op-order-delivery-packages`
@@ -558,8 +564,8 @@ Renders an order delivery packages information and product list. Must be placed 
 | `attachmentContent`       | Attachment's content wrapper                   |
 | `attachmentContentItem`   | Each attachment's content paragraph            |
 
-| Default appearance                                                     |
-| ---------------------------------------------------------------------- |
+| Default appearance                                                                                                                  |
+| ----------------------------------------------------------------------------------------------------------------------------------- |
 | ![op-order-delivery-packages](https://user-images.githubusercontent.com/17712401/89225054-f8e56e00-d5af-11ea-9c0a-b2cc37fe34f4.png) |
 
 ### `op-order-pickup-packages`
@@ -581,8 +587,8 @@ _Note: Include the same CSS handles as [`op-order-delivery-packages`](#op-order-
 | `packageReceiverName`   | Name of the package's **pickup** receiver                    |
 | `packageAdditionalInfo` | Wrapper of additional information about a **pickup** package |
 
-| Default appearance                                                 |
-| ------------------------------------------------------------------ |
+| Default appearance                                                                                                                |
+| --------------------------------------------------------------------------------------------------------------------------------- |
 | ![op-order-pickup-packages](https://user-images.githubusercontent.com/17712401/89225074-03076c80-d5b0-11ea-840e-69998a41ec9d.png) |
 
 ### `op-order-total`
@@ -601,8 +607,8 @@ Renders an order delivery packages information and product list. Must be placed 
 | `totalListItemLabel` | Label of a price item                       |
 | `totalListItemValue` | Value of a price item                       |
 
-| Default appearance                             |
-| ---------------------------------------------- |
+| Default appearance                                                                                                      |
+| ----------------------------------------------------------------------------------------------------------------------- |
 | ![op-order-total](https://user-images.githubusercontent.com/17712401/89225092-0b5fa780-d5b0-11ea-976e-da3c64453eff.png) |
 
 ## API

--- a/messages/ar.json
+++ b/messages/ar.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "هل تجد صعوبة في مشاهد {paymentSystemName} الخاص بك؟",
   "store/header.bankinvoice.tooltip": "{paymentSystemName} الخاص بك يعمل بشكل طبيعي. انقر فوق {message} أو انسخ الرمز الشريطي الخاص بها لمتابعة الدفع.",
   "store/header.email": "في غضون 5 دقائق، ستتلقى رسالة بريد إلكتروني على {userEmail} تحتوي على جميع تفاصيل الشراء. {lineBreak} تذكر أن تتحقق من البريد العشوائي أو صندوق الوارد الخاص بالعروض الترويجية",
+  "store/header.guest-email": "في غضون 5 دقائق، ستتلقى رسالة بريد إلكتروني على {userEmail} تحتوي على جميع تفاصيل الشراء. {lineBreak} تذكر أن تتحقق من البريد العشوائي أو صندوق الوارد الخاص بالعروض الترويجية",
   "store/header.newpurchase.button": "بدء طلب جديد",
   "store/header.print.button": "طباعة",
   "store/header.thanks": "شكرًا لك على شرائك!",

--- a/messages/bg.json
+++ b/messages/bg.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Не виждате вашата {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Вашата {paymentSystemName} работи нормално. Щракнете върху {message} или копирайте баркода му, за да продължите с плащането.",
   "store/header.email": "В рамките на 5 минути ще получите имейл на {userEmail} с всички подробности за поръчката ви.{lineBreak}Не забравяйте да проверите вашия спам",
+  "store/header.guest-email": "В рамките на 5 минути ще получите имейл на {userEmail} с всички подробности за поръчката ви.{lineBreak}Не забравяйте да проверите вашия спам",
   "store/header.newpurchase.button": "Начало на нова поръчка",
   "store/header.print.button": "Печат",
   "store/header.thanks": "Благодарим ви за покупката!",

--- a/messages/ca.json
+++ b/messages/ca.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "No podeu veure el vostre {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "El vostre {paymentSystemName} funciona amb normalitat. Feu clic a {message} o copieu-ne el codi de barres per procedir al pagament.",
   "store/header.email": "Dins d'un termini de 5 minuts, rebreu un correu electrònic a {userEmail} amb tota la informació sobre la vostra compra.{lineBreak}Recordeu revisar la safata de correu brossa o la pestanya Promocions",
+  "store/header.guest-email": "Dins d'un termini de 5 minuts, rebreu un correu electrònic a {userEmail} amb tota la informació sobre la vostra compra.{lineBreak}Recordeu revisar la safata de correu brossa o la pestanya Promocions",
   "store/header.newpurchase.button": "Inicia una comanda nova",
   "store/header.print.button": "Imprimeix",
   "store/header.thanks": "Gràcies per la vostra compra!",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Nevidíte {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "{paymentSystemName} funguje normálně. Pro zaplacení klikněte na {message} nebo zkopírujte čárový kód.",
   "store/header.email": "Během 5 minut dostanete na adresu {userEmail} e-mail obsahující podrobnosti o vašem nákupu.{lineBreak}Nezapomeňte zkontrolovat složku pro spam nebo obchodní nabídky",
+  "store/header.guest-email": "Během 5 minut dostanete na adresu {userEmail} e-mail obsahující podrobnosti o vašem nákupu.{lineBreak}Nezapomeňte zkontrolovat složku pro spam nebo obchodní nabídky",
   "store/header.newpurchase.button": "Založit novou objednávku",
   "store/header.print.button": "Vytisknout",
   "store/header.thanks": "Děkujeme za váš nákup!",

--- a/messages/da.json
+++ b/messages/da.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Kan du ikke set dit {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Dit {paymentSystemName} virker normalt. Klik på {message} eller kopier stregkoden for at fortsætte med betalingen.",
   "store/header.email": "Inden for 5 minutter vil du modtage en e-mail på {userEmail} med alle dine købsdetaljer.{lineBreak}Husk at kontrollere din spam eller promoveringsindbakke",
+  "store/header.guest-email": "Inden for 5 minutter vil du modtage en e-mail på {userEmail} med alle dine købsdetaljer.{lineBreak}Husk at kontrollere din spam eller promoveringsindbakke",
   "store/header.newpurchase.button": "Start ny ordre",
   "store/header.print.button": "Udskriv",
   "store/header.thanks": "Tak for dit køb!",

--- a/messages/de.json
+++ b/messages/de.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Sie können Ihren {paymentSystemName} nicht sehen?",
   "store/header.bankinvoice.tooltip": "Ihr {paymentSystemName} funktioniert einwandfrei. Klicken Sie auf {message} oder kopieren Sie ihren Barcode, um mit der Zahlung fortzufahren.",
   "store/header.email": "Innerhalb von 5 Minuten erhalten Sie eine E-Mail an {userEmail} mit all Ihren Kaufdetails. {lineBreak} Denken Sie daran, Ihren Spam- oder Werbepostfach zu überprüfen",
+  "store/header.guest-email": "Innerhalb von 5 Minuten erhalten Sie eine E-Mail an {userEmail} mit all Ihren Kaufdetails. {lineBreak} Denken Sie daran, Ihren Spam- oder Werbepostfach zu überprüfen",
   "store/header.newpurchase.button": "Neue Bestellung starten",
   "store/header.print.button": "Drucken",
   "store/header.thanks": "Vielen Dank für Ihren Kauf!",

--- a/messages/el.json
+++ b/messages/el.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Δεν μπορείτε να δείτε {paymentSystemName};",
   "store/header.bankinvoice.tooltip": "Το {paymentSystemName} σας λειτουργεί κανονικά. Κάντε κλικ στο {message} ή αντιγράψτε τον γραμμωτό κώδικα για να προχωρήσει η πληρωμή.",
   "store/header.email": "Εντός 5 λεπτών, θα λάβετε email στο {userEmail} με όλα τα στοιχεία της αγοράς σας.{lineBreak}Θυμηθείτε να ελέγχετε την ανεπιθύμητη αλληλογραφία ή τα διαφημιστικά μηνύματα",
+  "store/header.guest-email": "Εντός 5 λεπτών, θα λάβετε email στο {userEmail} με όλα τα στοιχεία της αγοράς σας.{lineBreak}Θυμηθείτε να ελέγχετε την ανεπιθύμητη αλληλογραφία ή τα διαφημιστικά μηνύματα",
   "store/header.newpurchase.button": "Ξεκίνημα νέας παραγγελίας",
   "store/header.print.button": "Εκτύπωση",
   "store/header.thanks": "Ευχαριστούμε για την αγορά σας!",

--- a/messages/en.json
+++ b/messages/en.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Can't see your {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Your {paymentSystemName} is working normally. Click on {message} or copy its barcode to proceed with payment.",
   "store/header.email": "Within 5 minutes, you will receive an email at {userEmail} with all of your purchase details.{lineBreak}Remember to check your spam or promotions inbox",
+  "store/header.guest-email": "Within 5 minutes, you will receive an email at {userEmail} with all of your purchase details.{lineBreak}Remember to check your spam or promotions inbox",
   "store/header.newpurchase.button": "Start new order",
   "store/header.print.button": "Print",
   "store/header.thanks": "Thank you for your purchase!",

--- a/messages/es.json
+++ b/messages/es.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "¿No puede ver su {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Su {paymentSystemName} está funcionando con normalidad. Haga clic en {message} o copie su código para efectuar el pago",
   "store/header.email": "En hasta 5 minutos, recibirá un correo electrónico en {userEmail} con todos los detalles de su compra. {lineBreak} Recuerde revisar su buzón de correo no deseado o promociones.",
+  "store/header.guest-email": "En hasta 5 minutos, recibirá un correo electrónico en {userEmail} con todos los detalles de su compra. {lineBreak} Recuerde revisar su buzón de correo no deseado o promociones.",
   "store/header.newpurchase.button": "Empezar nuevo orden",
   "store/header.print.button": "Imprimir",
   "store/header.thanks": "¡Gracias por la compra!",

--- a/messages/fi.json
+++ b/messages/fi.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Etkö näe maksupalvelua {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Maksupalvelusi {paymentSystemName} toimii normaalisti. Napsauta {message} tai kopioi sen viivakoodi jatkaaksesi maksamista.",
   "store/header.email": "Saat viiden minuutin kuluessa osoitteeseen {userEmail} viestin, joka sisältää kaikki ostotapahtuman tiedot.{lineBreak}Muista tarkastaa roskaposti- tai mainoslaatikko",
+  "store/header.guest-email": "Saat viiden minuutin kuluessa osoitteeseen {userEmail} viestin, joka sisältää kaikki ostotapahtuman tiedot.{lineBreak}Muista tarkastaa roskaposti- tai mainoslaatikko",
   "store/header.newpurchase.button": "Aloita uusi tilaus",
   "store/header.print.button": "Tulosta",
   "store/header.thanks": "Kiitos ostostasi!",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Vous ne voyez pas votre {paymentSystemName} ?",
   "store/header.bankinvoice.tooltip": "Votre {paymentSystemName} fonctionne normalement. Cliquez sur {message} ou copiez son code barre pour procéder au paiement.",
   "store/header.email": "Dans les 5 prochaines minutes, vous recevrez un courriel à {userEmail} avec tous les détails de votre achat.{lineBreak} N'oubliez pas de consulter votre boîte de réception de spam ou de promotions",
+  "store/header.guest-email": "Dans les 5 prochaines minutes, vous recevrez un courriel à {userEmail} avec tous les détails de votre achat.{lineBreak} N'oubliez pas de consulter votre boîte de réception de spam ou de promotions",
   "store/header.newpurchase.button": "Démarrer une nouvelle commande",
   "store/header.print.button": "Imprimer",
   "store/header.thanks": "Merci pour votre achat !",

--- a/messages/hu-HU.json
+++ b/messages/hu-HU.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Nem látja a következőt: {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "A(z) {paymentSystemName} megfelelően működik. Kattintson a(z) {message} lehetőségre, vagy másolja ki a vonalkódot a fizetés folytatásához.",
   "store/header.email": "5 percen belül e-mailt kap a(z) {userEmail} címre a vásárlás részleteiről.{lineBreak}Ne felejtse el ellenőrizni a levélszemetet vagy hirdetéseket tartalmazó mappákat",
+  "store/header.guest-email": "5 percen belül e-mailt kap a(z) {userEmail} címre a vásárlás részleteiről.{lineBreak}Ne felejtse el ellenőrizni a levélszemetet vagy hirdetéseket tartalmazó mappákat",
   "store/header.newpurchase.button": "Új megrendelés indítása",
   "store/header.print.button": "Nyomtatás",
   "store/header.thanks": "Köszönjük a vásárlást!",

--- a/messages/it.json
+++ b/messages/it.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Non riesci a visualizzare il tuo {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Il tuo {paymentSystemName} funziona normalmente. Fai clic su {message} o copia il suo codice a barre per procedere con il pagamento.",
   "store/header.email": "Entro circa 5 minuti riceverai un'email all'indirizzo {userEmail} contenente tutti i dettagli del tuo acquisto.{lineBreak}Ricorda di controllare la tua cartella Spam o Promozioni",
+  "store/header.guest-email": "Entro circa 5 minuti riceverai un'email all'indirizzo {userEmail} contenente tutti i dettagli del tuo acquisto.{lineBreak}Ricorda di controllare la tua cartella Spam o Promozioni",
   "store/header.newpurchase.button": "Inizia un nuovo ordine",
   "store/header.print.button": "Stampa",
   "store/header.thanks": "Grazie per il tuo acquisto!",

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "{paymentSystemName} が表示されませんか？",
   "store/header.bankinvoice.tooltip": "{paymentSystemName} が正常に作動していません。{message} をクリックするか、またはバーコードをコピーして支払いを進めてください。",
   "store/header.email": "5 分以内に、すべての購入品の詳細について {userEmail} へメールが届きます。{lineBreak}迷惑メールフォルダやプロモーションの受信トレイもご確認ください。",
+  "store/header.guest-email": "5 分以内に、すべての購入品の詳細について {userEmail} へメールが届きます。{lineBreak}迷惑メールフォルダやプロモーションの受信トレイもご確認ください。",
   "store/header.newpurchase.button": "新しい注文を始める",
   "store/header.print.button": "印刷",
   "store/header.thanks": "お買い上げいただき、ありがとうございます！",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "{paymentSystemName} 이 보이지 않습니까?",
   "store/header.bankinvoice.tooltip": "{paymentSystemName} 이 정상적으로 작동합니다. 결제를 진행하려면 {message} 를 클릭하거나 바코드를 복사하세요.",
   "store/header.email": "5분 내에 {userEmail}로 모든 구매 상세 정보가 포함된 이메일을 수신하게 됩니다.{lineBreak}스팸함이나 프로모션 수신함 확인을 잊지 마십시오",
+  "store/header.guest-email": "5분 내에 {userEmail}로 모든 구매 상세 정보가 포함된 이메일을 수신하게 됩니다.{lineBreak}스팸함이나 프로모션 수신함 확인을 잊지 마십시오",
   "store/header.newpurchase.button": "새 주문 시작하기",
   "store/header.print.button": "인쇄",
   "store/header.thanks": "구매해 주셔서 감사합니다!",

--- a/messages/nl.json
+++ b/messages/nl.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Kan je uw {paymentSystemName} niet zien?",
   "store/header.bankinvoice.tooltip": "Uw {paymentSystemName} werkt normaal. Klik op {message} of kopieer zijn barcode om door te gaan met de betaling.",
   "store/header.email": "Binnen 5 minuten ontvangt u een e-mail op {userEmail} met al uw aankoopgegevens.{lineBreak}Vergeet niet om uw spam of promoties inbox te controleren",
+  "store/header.guest-email": "Binnen 5 minuten ontvangt u een e-mail op {userEmail} met al uw aankoopgegevens.{lineBreak}Vergeet niet om uw spam of promoties inbox te controleren",
   "store/header.newpurchase.button": "Start nieuwe bestelling",
   "store/header.print.button": "Print",
   "store/header.thanks": "Bedankt voor uw aankoop!",

--- a/messages/nn.json
+++ b/messages/nn.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Kan du ikke se {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "{paymentSystemName} fungerer normalt. Klikk på {message} eller kopier strekkoden for å fortsette med betalingen.",
   "store/header.email": "I løpet av fem minutter vil du motta en e-post på {userEmail} med alle kjøpsdetaljene dine. {lineBreak} Husk å sjekke innboksen for søppelpost eller kampanjer",
+  "store/header.guest-email": "I løpet av fem minutter vil du motta en e-post på {userEmail} med alle kjøpsdetaljene dine. {lineBreak} Husk å sjekke innboksen for søppelpost eller kampanjer",
   "store/header.newpurchase.button": "Start ny bestilling",
   "store/header.print.button": "Skriv ut",
   "store/header.thanks": "Takk for kjøpet!",

--- a/messages/no.json
+++ b/messages/no.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Kan du ikke se {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "{paymentSystemName} fungerer normalt. Klikk på {message} eller kopier strekkoden for å fortsette med betalingen.",
   "store/header.email": "I løpet av fem minutter vil du motta en e-post på {userEmail} med alle kjøpsdetaljene dine. {lineBreak} Husk å sjekke innboksen for søppelpost eller kampanjer",
+  "store/header.guest-email": "I løpet av fem minutter vil du motta en e-post på {userEmail} med alle kjøpsdetaljene dine. {lineBreak} Husk å sjekke innboksen for søppelpost eller kampanjer",
   "store/header.newpurchase.button": "Start ny bestilling",
   "store/header.print.button": "Skriv ut",
   "store/header.thanks": "Takk for kjøpet!",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Nie widzisz swojego {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Twój {paymentSystemName} działa normalnie. Kliknij {message} lub skopiuj jej kod kreskowy, aby przejść do płatności.",
   "store/header.email": "Za najwyżej 5 minut otrzymasz od nas email na adres {userEmail} ze wszystkimi szczegółami Twojego zakupu.{lineBreak}Pamiętaj, aby sprawdzić SPAM lub skrzynkę email z promocjami",
+  "store/header.guest-email": "Za najwyżej 5 minut otrzymasz od nas email na adres {userEmail} ze wszystkimi szczegółami Twojego zakupu.{lineBreak}Pamiętaj, aby sprawdzić SPAM lub skrzynkę email z promocjami",
   "store/header.newpurchase.button": "Rozpocznij nowe zamówienie",
   "store/header.print.button": "Drukuj",
   "store/header.thanks": "Dziękujemy za zakup!",

--- a/messages/pt-PT.json
+++ b/messages/pt-PT.json
@@ -8,6 +8,7 @@
     "store/header.bankinvoice.help": "Não consegue ver o seu {paymentSystemName}?",
     "store/header.bankinvoice.tooltip": "Seu {paymentSystemName} está funcionando normalmente! Clique em {message} ou copie seu código para efetuar o pagamento.",
     "store/header.email": "Dentro de 5 min. vamos mandar um e-mail para {userEmail} com todos os detalhes do seu pedido.{lineBreak}Confira a caixa de spam ou aba de promoções.",
+    "store/header.guest-email": "Dentro de 5 min. vamos mandar um e-mail para {userEmail} com todos os detalhes do seu pedido.{lineBreak}Confira a caixa de spam ou aba de promoções.",
     "store/header.newpurchase.button": "Iniciar nova venda",
     "store/header.print.button": "Imprimir página",
     "store/header.thanks": "Obrigado pela sua compra!",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Não consegue ver o seu {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Seu {paymentSystemName} está funcionando normalmente! Clique em {message} ou copie seu código para efetuar o pagamento.",
   "store/header.email": "Em até 5 min. vamos mandar um e-mail para {userEmail} com todos os detalhes do seu pedido.{lineBreak}Confira a caixa de spam ou aba de promoções.",
+  "store/header.guest-email": "Em até 5 min. vamos mandar um e-mail para {userEmail} com todos os detalhes do seu pedido.{lineBreak}Confira a caixa de spam ou aba de promoções.",
   "store/header.newpurchase.button": "Iniciar nova venda",
   "store/header.print.button": "Imprimir página",
   "store/header.thanks": "Obrigado por sua compra!",

--- a/messages/ro.json
+++ b/messages/ro.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Nu poți vedea {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "{paymentSystemName} funcționează normal. Apasă pe {message} sau copiază codul de bare pentru a continua cu plata.",
   "store/header.email": "În cel mult 5 minute vei primi un e-mail la {userEmail} cu toate detaliile achiziției tale.{lineBreak} Verifică mesajele spam sau promoționale",
+  "store/header.guest-email": "În cel mult 5 minute vei primi un e-mail la {userEmail} cu toate detaliile achiziției tale.{lineBreak} Verifică mesajele spam sau promoționale",
   "store/header.newpurchase.button": "Începe comandă nouă ",
   "store/header.print.button": "Imprimare ",
   "store/header.thanks": "Mulțumim pentru achiziție!",

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Не видите ваш {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Ваш {paymentSystemName} работает нормально. Нажмите на «{message}» или скопируйте штрихкод, чтобы выполнить платёж.",
   "store/header.email": "В течении 5 минут, на адрес {userEmail} будет отправлено письмо со всеми деталями вашего заказа.{lineBreak}Не забудьте проверить спам",
+  "store/header.guest-email": "В течении 5 минут, на адрес {userEmail} будет отправлено письмо со всеми деталями вашего заказа.{lineBreak}Не забудьте проверить спам",
   "store/header.newpurchase.button": "Начать новый заказ",
   "store/header.print.button": "Распечатать",
   "store/header.thanks": "Спасибо за покупку!",

--- a/messages/sk.json
+++ b/messages/sk.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Nevidíte {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Váš {paymentSystemName} funguje normálne. Kliknite na {message} alebo skopírujte príslušný čiarový kód pokračujte v platbe.",
   "store/header.email": "Do 5 minút dostanete e-mail na adresu {userEmail} so všetkými podrobnosťami o nákupe.{lineBreak}Nezabudnite skontrolovať priečinok doručenej pošty alebo priečinok reklamy",
+  "store/header.guest-email": "Do 5 minút dostanete e-mail na adresu {userEmail} so všetkými podrobnosťami o nákupe.{lineBreak}Nezabudnite skontrolovať priečinok doručenej pošty alebo priečinok reklamy",
   "store/header.newpurchase.button": "Začať novú objednávku",
   "store/header.print.button": "Vytlačiť",
   "store/header.thanks": "Ďakujeme vám za nákup!",

--- a/messages/sl.json
+++ b/messages/sl.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Ne morete videti vašega {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Vaš {paymentSystemName} deluje normalno. Kliknite na {message} ali kopirajte njegovo črtno kodo, da nadaljujete s plačilom.",
   "store/header.email": "V 5 minuta boste prejeli e-pošto na {userEmail} z vsemi vašimi podrobnostmi nakupa.{lineBreak}Spomnite se, da preverite vašo nezaželeno pošto ali promocijski poštni predal",
+  "store/header.guest-email": "V 5 minuta boste prejeli e-pošto na {userEmail} z vsemi vašimi podrobnostmi nakupa.{lineBreak}Spomnite se, da preverite vašo nezaželeno pošto ali promocijski poštni predal",
   "store/header.newpurchase.button": "Začnite novo naročilo",
   "store/header.print.button": "Tiskaj",
   "store/header.thanks": "Hvala vam za vaš nakup!",

--- a/messages/sv.json
+++ b/messages/sv.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Kan inte se din {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Din {paymentSystemName} fungerar normalt. Klicka på {message} eller kopiera streckkoden för att fortsätta med betalningen.",
   "store/header.email": "Inom 5 minuter kommer du att få ett e-postmeddelande till {userEmail} med all dina köpinformation. {lineBreak}Kom ihåg att kolla din skräppost eller inkorg för kampanjer",
+  "store/header.guest-email": "Inom 5 minuter kommer du att få ett e-postmeddelande till {userEmail} med all dina köpinformation. {lineBreak}Kom ihåg att kolla din skräppost eller inkorg för kampanjer",
   "store/header.newpurchase.button": "Påbörja ny beställning",
   "store/header.print.button": "Skriv ut",
   "store/header.thanks": "Tack för ditt köp!",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -8,6 +8,7 @@
   "store/header.bankinvoice.help": "Не бачите ваш {paymentSystemName}?",
   "store/header.bankinvoice.tooltip": "Ваш {paymentSystemName} працює нормально. Натисніть на «{message}» або скопіюйте штрихкод, щоби здійснити платіж.",
   "store/header.email": "Протягом 5 хвилин ви отримаєте електронний лист на {userEmail} з усіма деталями покупки.{lineBreak}Не забудьте перевірити папку \"Спам\" або \"Акції\"",
+  "store/header.guest-email": "Протягом 5 хвилин ви отримаєте електронний лист на {userEmail} з усіма деталями покупки.{lineBreak}Не забудьте перевірити папку \"Спам\" або \"Акції\"",
   "store/header.newpurchase.button": "Почати нове замовлення",
   "store/header.print.button": "Друкувати",
   "store/header.thanks": "Дякуємо за покупку!",

--- a/react/ConfirmationMessage.tsx
+++ b/react/ConfirmationMessage.tsx
@@ -7,7 +7,13 @@ import { useSessionResponse } from './utils/useSessionResponse'
 
 const CSS_HANDLES = ['confirmationMessage']
 
-const ConfirmationMessage: FC = () => {
+interface Props {
+  enableGuestMessage: boolean
+}
+
+const ConfirmationMessage: FC<Props> = ({
+  enableGuestMessage = false,
+}: Props) => {
   const handles = useCssHandles(CSS_HANDLES)
   const orderGroup = useOrderGroup()
   const profile = orderGroup.orders[0].clientProfileData
@@ -22,9 +28,9 @@ const ConfirmationMessage: FC = () => {
     <p
       className={`${handles.confirmationMessage} mt5 t-body tc c-muted-1 lh-copy`}
     >
-      {isLoggedIn ? (
+      {!isLoggedIn && enableGuestMessage ? (
         <FormattedMessage
-          id="store/header.email"
+          id="store/header.guest-email"
           values={{
             lineBreak: <br />,
             userEmail: <strong className="nowrap">{profile.email}</strong>,
@@ -32,7 +38,7 @@ const ConfirmationMessage: FC = () => {
         />
       ) : (
         <FormattedMessage
-          id="store/header.guest-email"
+          id="store/header.email"
           values={{
             lineBreak: <br />,
             userEmail: <strong className="nowrap">{profile.email}</strong>,

--- a/react/ConfirmationMessage.tsx
+++ b/react/ConfirmationMessage.tsx
@@ -1,8 +1,9 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect, useState } from 'react'
 import { FormattedMessage } from 'react-intl'
 import { useCssHandles } from 'vtex.css-handles'
 
 import { useOrderGroup } from './components/OrderGroupContext'
+import { useSessionResponse } from './utils/useSessionResponse'
 
 const CSS_HANDLES = ['confirmationMessage']
 
@@ -10,18 +11,34 @@ const ConfirmationMessage: FC = () => {
   const handles = useCssHandles(CSS_HANDLES)
   const orderGroup = useOrderGroup()
   const profile = orderGroup.orders[0].clientProfileData
+  const sessionResponse = useSessionResponse()
+  const [isLoggedIn, setIsLoggedIn] = useState(true)
+
+  useEffect(() => {
+    setIsLoggedIn(!!sessionResponse?.namespaces?.profile?.email)
+  }, [sessionResponse, setIsLoggedIn])
 
   return (
     <p
       className={`${handles.confirmationMessage} mt5 t-body tc c-muted-1 lh-copy`}
     >
-      <FormattedMessage
-        id="store/header.email"
-        values={{
-          lineBreak: <br />,
-          userEmail: <strong className="nowrap">{profile.email}</strong>,
-        }}
-      />
+      {isLoggedIn ? (
+        <FormattedMessage
+          id="store/header.email"
+          values={{
+            lineBreak: <br />,
+            userEmail: <strong className="nowrap">{profile.email}</strong>,
+          }}
+        />
+      ) : (
+        <FormattedMessage
+          id="store/header.guest-email"
+          values={{
+            lineBreak: <br />,
+            userEmail: <strong className="nowrap">{profile.email}</strong>,
+          }}
+        />
+      )}
     </p>
   )
 }

--- a/react/ConfirmationMessage.tsx
+++ b/react/ConfirmationMessage.tsx
@@ -24,6 +24,9 @@ const ConfirmationMessage: FC<Props> = ({
     setIsLoggedIn(!!sessionResponse?.namespaces?.profile?.email)
   }, [sessionResponse, setIsLoggedIn])
 
+  // by default "header.email" and "header.guest-email" texts are the same
+  // if the customer enables the guest message option, they will also need to change the guest text via GraphQL
+
   return (
     <p
       className={`${handles.confirmationMessage} mt5 t-body tc c-muted-1 lh-copy`}

--- a/react/utils/useSessionResponse.tsx
+++ b/react/utils/useSessionResponse.tsx
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { useEffect, useMemo, useState } from 'react'
+
+export const useSessionResponse = () => {
+  const [session, setSession] = useState<any>()
+  const sessionPromise = useMemo(
+    () =>
+      ((window as any).__RENDER_8_SESSION__?.sessionPromise as Promise<any>) ??
+      undefined,
+    []
+  )
+
+  useEffect(() => {
+    if (!sessionPromise) {
+      return
+    }
+
+    sessionPromise.then((sessionResponse: any) => {
+      setSession(sessionResponse?.response)
+    })
+  }, [sessionPromise, setSession])
+
+  return session
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

To add a separate message for guest users to the order confirmation message component. This way, logged in users will see the default message (store/header.email) and guest users will see a different message (store/header.guest-email).

#### What problem is this solving?

Some of customers want to show different confirmation messages depends on "is user logged in" state

#### How should this be manually tested?

https://devalex--dunnesstoresqa.myvtex.com/checkout/orderPlaced/?og=50506720

#### Screenshots or example usage

<img width="1072" alt="guest message" src="https://github.com/user-attachments/assets/40d2e79e-ae2d-4ad3-ac5c-1ea92e02993f">
<img width="1054" alt="logged in user message" src="https://github.com/user-attachments/assets/5e017e0f-fae7-4a76-8444-310da0842f7e">

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
