### PR TITLE
fix: display of bank invoice information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.18.1] - 2024-12-27
+
+### Fixed
+
+- Fix the display of bank invoice information when it isn't the first payment of the first transaction.
+
 ## [2.18.0] - 2024-08-27
 
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "order-placed",
-  "version": "2.18.1",
+  "version": "2.18.0",
   "title": "Order Placed",
   "description": "",
   "registries": ["smartcheckout"],

--- a/manifest.json
+++ b/manifest.json
@@ -1,12 +1,10 @@
 {
   "vendor": "vtex",
   "name": "order-placed",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "title": "Order Placed",
   "description": "",
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --public"
   },

--- a/react/Notices.tsx
+++ b/react/Notices.tsx
@@ -25,18 +25,18 @@ const Notices: FC = () => {
       const hasBankInvoiceA = a.payments.some((p) => p.group === 'bankInvoice')
       const hasBankInvoiceB = b.payments.some((p) => p.group === 'bankInvoice')
 
-      if (hasBankInvoiceA !== hasBankInvoiceB) {
-        if (hasBankInvoiceA) {
-          return -1
-        }
-
-        if (hasBankInvoiceB) {
-          return 1
-        }
+      if (hasBankInvoiceA === hasBankInvoiceB) {
+            return 0
       }
-
-      return 0
-    })
+      
+      if (hasBankInvoiceA) {
+            return -1
+      }
+      
+      if (hasBankInvoiceB) {
+            return 1
+      }
+    
   }
 
   const sortPayments = (payments: Payment[]) => {

--- a/react/Notices.tsx
+++ b/react/Notices.tsx
@@ -20,6 +20,20 @@ const Notices: FC = () => {
     return null
   }
 
+  orders.forEach((order) => {
+    order.paymentData.transactions.sort((transaction) =>
+      transaction.payments.some((payment) => payment.group === 'bankInvoice')
+        ? -1
+        : 1
+    )
+
+    order.paymentData.transactions.forEach((transaction) => {
+      transaction.payments.sort((payment) =>
+        payment.group === 'bankInvoice' ? -1 : 1
+      )
+    })
+  })
+
   const numOrders = orders.length
   const isSplitOrder = numOrders > 1
   const bankInvoice = orders


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
Fix a bug.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
In orders where the bank invoice payment method wasn't the first payment of the first transaction, its information wasn't displayed at the order placed page

#### How should this be manually tested?
There are 2 use cases for this change:
- Orders with a single transaction with multiple payments, in which the one of them is a bank invoice and it isn't in the first position of the payments array;
- Orders with multiple transactions in which one of them has a bank invoice payment, and this transaction isn't the first of the array.

#### Screenshots or example usage
Example of an order with bank invoice in the second payment of the array, where its information is not displayed:
https://gaboulstore.myvtex.com/checkout/orderPlaced/?og=1486610500025
![image](https://github.com/user-attachments/assets/2b0a1166-3df6-4ce3-95e1-9a945539954c)

Example of the same order, but in a workspace with this change implemented:
https://bankinvoice--gaboulstore.myvtex.com/checkout/orderPlaced/?og=1486610500025
![image](https://github.com/user-attachments/assets/8977047f-cc9d-42d9-922c-f5f04aa987e6)



#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
