### PR TITLE
Update owner of order-placed to te-0001

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   type: frontend-ui
   lifecycle: experimental
-  owner: checkout-experience
+  owner: te-0001
   system: checkout
   dependsOn:
     - component:order-placed-graphql


### PR DESCRIPTION
This PR updates the owner of order-placed to te-0001 in the catalog-info.yaml file.
This is necessary because now in DK Portal we will define the team -> component relationship through the team id instead of the owner name.