### PR TITLE
Include receiver name in DeliveryHeader

### DIFF
--- a/react/components/DeliveryHeader.tsx
+++ b/react/components/DeliveryHeader.tsx
@@ -19,6 +19,8 @@ const CSS_HANDLES = [
   'packageAddressWrapper',
   'packageAddressTitle',
   'packageDeliveryTitle',
+  'packageReceiver',
+  'packageReceiverName',
 ] as const
 
 const DeliveryHeader: FC<Props> = ({
@@ -29,6 +31,7 @@ const DeliveryHeader: FC<Props> = ({
 }) => {
   const handles = useCssHandles(CSS_HANDLES)
   const multipleDeliveries = numPackages > 1
+  const { receiverName } = shippingData.address
 
   return (
     <Fragment>
@@ -80,6 +83,11 @@ const DeliveryHeader: FC<Props> = ({
             <FormattedMessage id="store/shipping.header.address" />
           </span>
           <Address address={shippingData.address} />
+          {receiverName && (
+            <div className={`${handles.packageReceiver} c-on-base lh-copy mt5`}>
+              <p className={`${handles.packageReceiverName}`}>{receiverName}</p>
+            </div>
+          )}
         </div>
       )}
     </Fragment>


### PR DESCRIPTION
Add receiver name display to DeliveryHeader component. Change requested through ticket #1393065.

#### What is the purpose of this pull request?
Add the receiverName to the orders placed page when the order has delivery as the shipping method.

#### How should this be manually tested?
Use this workspace https://testorder--desafioonboarding30.myvtex.com/checkout/cart/add/?sku=92&qty=1&seller=1&sc=1

#### Screenshots or example usage
current behavior
<img width="1232" height="964" alt="image" src="https://github.com/user-attachments/assets/a06727ca-4d1f-4d05-af70-0b622c84a8d0" />


Expected Behavior
<img width="2556" height="586" alt="image" src="https://github.com/user-attachments/assets/598857ed-8ba3-4fa9-b8a3-36b2f26d1f3f" />


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which will be updated after the PR's approval.
